### PR TITLE
Adding ability for colour to be disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+
+go:
+  - 1.7
+  - tip
+
+before_install:
+  - go get -v github.com/golang/lint/golint
+
+script:
+  - make clean
+  - make vet
+  - make lint
+  - make errcheck
+  - make test
+  - make build
+  - make test-integration
+
+matrix:
+  allow_failures:
+    - go: tip

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # gopass
 
+[![Build Status](https://travis-ci.org/justwatchcom/gopass.svg?branch=master)](https://travis-ci.org/justwatchcom/gopass)
 [![Go Report Card](https://goreportcard.com/badge/github.com/justwatchcom/gopass)](https://goreportcard.com/report/github.com/justwatchcom/gopass)
 
 The slightly more awesome Standard Unix Password Manager for Teams. Written in Go.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ path: /home/tex/.password-store
 persistkeys: false
 ```
 
+Note that if a configuration file isn't present on disk, it will be written when you first run `gopass`.
+
 ### Managing Recipients
 
 You can list, add and remove recpients from the commandline.
@@ -258,6 +260,14 @@ gopass
 ├── 0xB1C7DF661ABB2C1A - Someone <someone@example.com>
 └── 0xB5B44266A3683834 - Gopher <gopher@golang.org>
 ```
+
+### Debugging
+
+To debug `gopass`, set the environment variable `GOPASS_DEBUG` to `true`.
+
+### Disabling Colors
+
+Disabling colours is as simple as `gopass config nocolors true`.
 
 ## Known Limitations and Caveats
 

--- a/README.md
+++ b/README.md
@@ -242,8 +242,6 @@ path: /home/tex/.password-store
 persistkeys: false
 ```
 
-Note that if a configuration file isn't present on disk, it will be written when you first run `gopass`.
-
 ### Managing Recipients
 
 You can list, add and remove recpients from the commandline.

--- a/action/action.go
+++ b/action/action.go
@@ -22,25 +22,24 @@ type Action struct {
 
 // New returns a new Action wrapper
 func New(v string) *Action {
-	if gdb := os.Getenv("GOPASS_DEBUG"); gdb == "true" {
-		gpg.Debug = true
-	}
-	if nc := os.Getenv("GOPASS_NOCOLOR"); nc == "true" {
-		color.NoColor = true
-	}
 	name := "gopass"
 	if len(os.Args) > 0 {
 		name = filepath.Base(os.Args[0])
 	}
 
+	if gdb := os.Getenv("GOPASS_DEBUG"); gdb == "true" {
+		gpg.Debug = true
+	}
 	pwDir := pwStoreDir("")
 
 	// try to read config (if it exists)
 	if cfg, err := newFromFile(configFile()); err == nil && cfg != nil {
 		cfg.ImportFunc = askForKeyImport
 		cfg.Version = v
+		color.NoColor = cfg.NoColor
+
 		return &Action{
-			Name:  name,
+			Name: name,
 			Store: cfg,
 		}
 	}
@@ -53,13 +52,16 @@ func New(v string) *Action {
 	cfg.ImportFunc = askForKeyImport
 	cfg.FsckFunc = askForConfirmation
 	cfg.Version = v
+
+	// write the config to disk for persisten
+	writeConfig(cfg)
 	return &Action{
 		Name:  name,
 		Store: cfg,
 	}
 }
 
-// newFromFile creates a new RootStore instance by unmarsahling a config file.
+// newFromFile creates a new RootStore instance by unmarshaling a config file.
 // If the file doesn't exist or fails to unmarshal an error is returned
 func newFromFile(cf string) (*password.RootStore, error) {
 	// deliberately using os.Stat here, a symlinked

--- a/action/action.go
+++ b/action/action.go
@@ -52,9 +52,7 @@ func New(v string) *Action {
 	cfg.ImportFunc = askForKeyImport
 	cfg.FsckFunc = askForConfirmation
 	cfg.Version = v
-
-	// write the config to disk for persisten
-	writeConfig(cfg)
+	
 	return &Action{
 		Name:  name,
 		Store: cfg,

--- a/gpg/gpg.go
+++ b/gpg/gpg.go
@@ -35,7 +35,18 @@ var (
 	GPGArgs = []string{"--quiet", "--yes", "--compress-algo=none", "--no-encrypt-to", "--no-auto-check-trustdb"}
 	// Debug prints all the commands executed
 	Debug = false
+	// GPGBin is the name and possibly location of the gpg binary
+	GPGBin = "gpg"
 )
+
+func init() {
+	for _, b := range []string{"gpg2", "gpg1", "gpg"} {
+		if p, err := exec.LookPath(b); err == nil {
+			GPGBin = p
+			break
+		}
+	}
+}
 
 // KeyList is a searchable slice of Keys
 type KeyList []Key
@@ -295,7 +306,7 @@ func (i Identity) String() string {
 func listKeys(typ string, search ...string) (KeyList, error) {
 	args := []string{"--with-colons", "--with-fingerprint", "--fixed-list-mode", "--list-" + typ + "-keys"}
 	args = append(args, search...)
-	cmd := exec.Command("gpg", args...)
+	cmd := exec.Command(GPGBin, args...)
 	if Debug {
 		fmt.Printf("gpg.listKeys: %s %+v\n", cmd.Path, cmd.Args)
 	}
@@ -326,7 +337,7 @@ func GetRecipients(file string) ([]string, error) {
 	recp := make([]string, 0, 5)
 
 	args := []string{"--batch", "--list-only", "--no-default-keyring", "--secret-keyring", "/dev/null", file}
-	cmd := exec.Command("gpg", args...)
+	cmd := exec.Command(GPGBin, args...)
 	if Debug {
 		fmt.Printf("gpg.GetRecipients: %s %+v\n", cmd.Path, cmd.Args)
 	}
@@ -373,7 +384,7 @@ func Encrypt(path string, content []byte, recipients []string, alwaysTrust bool)
 		args = append(args, "--recipient", r)
 	}
 
-	cmd := exec.Command("gpg", args...)
+	cmd := exec.Command(GPGBin, args...)
 	if Debug {
 		fmt.Printf("gpg.Encrypt: %s %+v\n", cmd.Path, cmd.Args)
 	}
@@ -391,7 +402,7 @@ func Encrypt(path string, content []byte, recipients []string, alwaysTrust bool)
 // Decrypt will try to decrypt the given file
 func Decrypt(path string) ([]byte, error) {
 	args := append(GPGArgs, "--decrypt", path)
-	cmd := exec.Command("gpg", args...)
+	cmd := exec.Command(GPGBin, args...)
 	if Debug {
 		fmt.Printf("gpg.Decrypt: %s %+v\n", cmd.Path, cmd.Args)
 	}
@@ -401,7 +412,7 @@ func Decrypt(path string) ([]byte, error) {
 // ExportPublicKey will export the named public key to the location given
 func ExportPublicKey(id, filename string) error {
 	args := append(GPGArgs, "--armor", "--export", id)
-	cmd := exec.Command("gpg", args...)
+	cmd := exec.Command(GPGBin, args...)
 	if Debug {
 		fmt.Printf("gpg.ExportPublicKey: %s %+v\n", cmd.Path, cmd.Args)
 	}
@@ -421,7 +432,7 @@ func ImportPublicKey(filename string) error {
 	}
 
 	args := append(GPGArgs, "--import")
-	cmd := exec.Command("gpg", args...)
+	cmd := exec.Command(GPGBin, args...)
 	if Debug {
 		fmt.Printf("gpg.ImportPublicKey: %s %+v\n", cmd.Path, cmd.Args)
 	}

--- a/main.go
+++ b/main.go
@@ -165,6 +165,7 @@ func main() {
 			Usage:        "List secrets that match the search term.",
 			Before:       action.Initialized,
 			Action:       action.Find,
+			Aliases:      []string{"search"},
 			BashComplete: action.Complete,
 		},
 		{

--- a/password/root_store.go
+++ b/password/root_store.go
@@ -22,6 +22,7 @@ type RootStore struct {
 	PersistKeys bool              `json:"persistkeys"` // store recipient keys in store
 	LoadKeys    bool              `json:"loadkeys"`    // load missing keys from store
 	ClipTimeout int               `json:"cliptimeout"` // clear clipboard after seconds
+	NoColor     bool              `json:"nocolor"`     // disable colors in output
 	Path        string            `json:"path"`        // path to the root store
 	Mount       map[string]string `json:"mounts,omitempty"`
 	Version     string            `json:"version"`


### PR DESCRIPTION
I've added the ability for colour to be disabled as per #4.

The config flag is simply `nocolor`. Note the lack of 'u' from my British English spelling. This was because I assumed the developers would likely be using American English.

Checking for the debugging environment variable was moved down a few lines for no particular reason at all. I moved it whilst trying to work out how-to integrate debugging into a config flag as well, but decided to just focus on the one flag instead. In the zone, I forgot to move it back to the top, but it has little difference.

For the `RootStore` struct key, I chose `NoColor` instead of `NoColors` (plural) to reflect the fact internally we're setting `color.NoColor` - I was looking to keep things consistent.

I felt the need to write the configuration to disk here on line 57 of `action.go`. When I was using the command to test what happened if I deleted my configuration and then checked the config, a new file wasn't written. This seemed odd to me, so I figured it was best we persistent what the user sees as I believe that would be a good user experience.

Slight typo in another file. Haven't checked all the code, though.

New config has been shown to work on my local compiled copy of `gopass`.

Versions:
- macOS 10.12
- gpg (GnuPG) 2.0.30 / libgcrypt 1.7.6 (gpg installed via brew)
- git version 2.11.0
- gopass HEAD (n/a ) go1.7.5