### PR TITLE
Check if ExpirationDate is set

### DIFF
--- a/gpg/gpg.go
+++ b/gpg/gpg.go
@@ -236,7 +236,7 @@ type Key struct {
 
 // IsUseable returns true if GPG would assume this key is useable for encryption
 func (k Key) IsUseable() bool {
-	if k.ExpirationDate.Before(time.Now()) {
+	if !k.ExpirationDate.IsZero() && k.ExpirationDate.Before(time.Now()) {
 		return false
 	}
 	switch k.Validity {


### PR DESCRIPTION
If the gpg key doesn't have an expiration date it is rejecting it, thinking it already expired. Is that expected?