### PR TITLE
Make gopass work if root password store directory is a symlink

### DIFF
--- a/fsutil/fsutil.go
+++ b/fsutil/fsutil.go
@@ -12,6 +12,11 @@ import (
 
 // CleanPath resolves common aliases in a path and cleans it as much as possible
 func CleanPath(path string) string {
+	if fi, err := os.Lstat(path); err == nil {
+		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+			path, _ = filepath.EvalSymlinks(path)
+		}
+	}
 	// http://stackoverflow.com/questions/17609732/expand-tilde-to-home-directory
 	if path[:2] == "~/" {
 		usr, _ := user.Current()

--- a/password/store.go
+++ b/password/store.go
@@ -62,13 +62,9 @@ func NewStore(alias, path string, r *RootStore) (*Store, error) {
 	if path == "" {
 		return nil, fmt.Errorf("Need path")
 	}
-	resolvedSymlinkPath, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return nil, fmt.Errorf("Could not resolve store path")
-	}
 	s := &Store{
 		alias:       alias,
-		path:        resolvedSymlinkPath,
+		path:        path,
 		autoPush:    r.AutoPush,
 		autoPull:    r.AutoPull,
 		autoImport:  r.AutoImport,

--- a/password/store.go
+++ b/password/store.go
@@ -62,9 +62,13 @@ func NewStore(alias, path string, r *RootStore) (*Store, error) {
 	if path == "" {
 		return nil, fmt.Errorf("Need path")
 	}
+	resolvedSymlinkPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil, fmt.Errorf("Could not resolve store path")
+	}
 	s := &Store{
 		alias:       alias,
-		path:        path,
+		path:        resolvedSymlinkPath,
 		autoPush:    r.AutoPush,
 		autoPull:    r.AutoPull,
 		autoImport:  r.AutoImport,


### PR DESCRIPTION
This PR fixes the issue I mentioned [here](https://github.com/justwatchcom/gopass/issues/40). I think this is all we need to resolve the secret store if the root is a symlink.

Here's the behavior of `gopass` with the patched version:

```
➤ ls -lad ~/.password-store
lrwxr-xr-x  1 hobbeswalsh  staff  22 Feb  6 15:02 /Users/hobbeswalsh/.password-store -> Dropbox/password-store

hobbeswalsh@mac:~/D/g/gopass|make_gopass_work_with_symlink_root_directory✓
➤ gopass | wc -l
     209
```