### PR TITLE
Add dmenu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,25 @@ autocompletion for subcommands like `gopass show`, `gopass ls` and others.
     source <(gopass completion bash)
     source <(gopass completion zsh)
 
+### dmenu support
+
+Out of the box gopass supports [dmenu](http://tools.suckless.org/dmenu/).
+Instead of shipping another bash script we ship dmenu support from within the binary.
+
+If you have dmenu installed on your system simply run:
+
+```bash
+$ gopass completion dmenu
+```
+The first line of your selected secret will be copied to your clipboard.
+
+Maybe you want the password to be written to your selected text field.
+For that add `--type` and make sure _xdotool_ is installed.
+
+```bash
+$ gopass completion dmenu --type
+```
+
 ### Dependencies
 
 `gopass` needs some external programs to work.

--- a/action/completion.go
+++ b/action/completion.go
@@ -51,3 +51,33 @@ source <(gopass completion bash)
 
 	return nil
 }
+
+// CompletionDMenu returns a script that starts dmenu
+// Usage: eval "$(pass completion dmenu)"
+func (s *Action) CompletionDMenu(
+	c *cli.Context) error {
+	out := `#!/usr/bin/env bash
+
+shopt -s nullglob globstar
+
+typeit=0
+if [[ $1 == "--type" ]]; then
+	typeit=1
+	shift
+fi
+
+password=$(gopass list --raw | dmenu "$@")
+
+[[ -n $password ]] || exit
+
+if [[ $typeit -eq 0 ]]; then
+	pass show -c "$password" 2>/dev/null
+else
+	pass show "$password" | { read -r pass; printf %s "$pass"; } |
+		xdotool type --clearmodifiers --file -
+fi
+`
+	fmt.Println(out)
+
+	return nil
+}

--- a/action/completion.go
+++ b/action/completion.go
@@ -54,8 +54,7 @@ source <(gopass completion bash)
 
 // CompletionDMenu returns a script that starts dmenu
 // Usage: eval "$(gopass completion dmenu)"
-func (s *Action) CompletionDMenu(
-	c *cli.Context) error {
+func (s *Action) CompletionDMenu(c *cli.Context) error {
 	out := `#!/usr/bin/env bash
 
 shopt -s nullglob globstar

--- a/action/completion.go
+++ b/action/completion.go
@@ -53,7 +53,7 @@ source <(gopass completion bash)
 }
 
 // CompletionDMenu returns a script that starts dmenu
-// Usage: eval "$(pass completion dmenu)"
+// Usage: eval "$(gopass completion dmenu)"
 func (s *Action) CompletionDMenu(
 	c *cli.Context) error {
 	out := `#!/usr/bin/env bash
@@ -71,9 +71,9 @@ password=$(gopass list --raw | dmenu "$@")
 [[ -n $password ]] || exit
 
 if [[ $typeit -eq 0 ]]; then
-	pass show -c "$password" 2>/dev/null
+	gopass show -c "$password" 2>/dev/null
 else
-	pass show "$password" | { read -r pass; printf %s "$pass"; } |
+	gopass show "$password" | { read -r pass; printf %s "$pass"; } |
 		xdotool type --clearmodifiers --file -
 fi
 `

--- a/action/list.go
+++ b/action/list.go
@@ -8,15 +8,7 @@ import (
 
 // List all secrets as a tree
 func (s *Action) List(c *cli.Context) error {
-	raw := c.Bool("raw")
 	filter := c.Args().First()
-
-	// Don't show a tree only new lines
-	if raw {
-		//TODO(metalmatze): Support filtering
-		s.Complete(c)
-		return nil
-	}
 
 	l, err := s.Store.Tree()
 	if err != nil {

--- a/action/list.go
+++ b/action/list.go
@@ -8,7 +8,15 @@ import (
 
 // List all secrets as a tree
 func (s *Action) List(c *cli.Context) error {
+	raw := c.Bool("raw")
 	filter := c.Args().First()
+
+	// Don't show a tree only new lines
+	if raw {
+		//TODO(metalmatze): Support filtering
+		s.Complete(c)
+		return nil
+	}
 
 	l, err := s.Store.Tree()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -113,6 +113,10 @@ func main() {
 				Name:   "zsh",
 				Usage:  "Source for auto completion in zsh",
 				Action: action.CompletionZSH,
+			}, {
+				Name:   "dmenu",
+				Usage:  "Completion output for dmenu",
+				Action: action.CompletionDMenu,
 			}},
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -298,6 +298,12 @@ func main() {
 			Before:       action.Initialized,
 			Action:       action.List,
 			BashComplete: action.Complete,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "raw",
+					Usage: "List all secrets on new lines without formatting",
+				},
+			},
 		},
 		{
 			Name:         "move",

--- a/main.go
+++ b/main.go
@@ -117,6 +117,12 @@ func main() {
 				Name:   "dmenu",
 				Usage:  "Completion output for dmenu",
 				Action: action.CompletionDMenu,
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "type",
+						Usage: "Type the password with xdotool",
+					},
+				},
 			}},
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -308,12 +308,6 @@ func main() {
 			Before:       action.Initialized,
 			Action:       action.List,
 			BashComplete: action.Complete,
-			Flags: []cli.Flag{
-				cli.BoolFlag{
-					Name:  "raw",
-					Usage: "List all secrets on new lines without formatting",
-				},
-			},
 		},
 		{
 			Name:         "move",

--- a/password/root_store.go
+++ b/password/root_store.go
@@ -1,6 +1,7 @@
 package password
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -301,6 +302,21 @@ func (r *RootStore) Get(name string) ([]byte, error) {
 	// forward to substore
 	store := r.getStore(name)
 	return store.Get(strings.TrimPrefix(name, store.alias))
+}
+
+// First returns the first line of the plaintext of a single key
+func (r *RootStore) First(name string) ([]byte, error) {
+	content, err := r.Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := bytes.Split(content, []byte("\n"))
+	if len(lines) < 1 {
+		return nil, fmt.Errorf("no content to return the first line from")
+	}
+
+	return bytes.TrimSpace(lines[0]), nil
 }
 
 // Exists checks the existence of a single entry


### PR DESCRIPTION
Closes #43 

The passmenu works but doesn't support mounts.

This add the script into the binary, just like auto completion for bash & zsh.
Some parts are still WIP and are probably going to change.

Usage: `eval "$(pass completion dmenu)"`

What do you think @notandy & @fortytw2?