### PR TITLE
Use editor command if $EDITOR is not set

### DIFF
--- a/action/edit.go
+++ b/action/edit.go
@@ -50,7 +50,7 @@ func (s *Action) Edit(c *cli.Context) error {
 func (s *Action) editor(content []byte) ([]byte, error) {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
-		return []byte{}, fmt.Errorf("failed to edit, please set $EDITOR")
+		editor = "editor"
 	}
 
 	tmpfile, err := ioutil.TempFile(fsutil.Tempdir(), "gopass-edit")


### PR DESCRIPTION
This restores compatibility with `pass` which uses `${EDITOR:-editor}`.