### PR TITLE
Run Travis builds with Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7
+  - 1.8
   - tip
 
 before_install:


### PR DESCRIPTION
This PR changes the Travis CI config to build gopass with go 1.8.