### PR TITLE
Bypass prompts on gopass insert --force

### DIFF
--- a/action/insert.go
+++ b/action/insert.go
@@ -15,6 +15,10 @@ func (s *Action) Insert(c *cli.Context) error {
 	echo := c.Bool("echo")
 	multiline := c.Bool("multiline")
 	force := c.Bool("force")
+	confirm := s.confirmRecipients
+	if force {
+		confirm = nil
+	}
 
 	name := c.Args().Get(0)
 	if name == "" {
@@ -34,7 +38,7 @@ func (s *Action) Insert(c *cli.Context) error {
 			return fmt.Errorf("Failed to copy after %d bytes: %s", written, err)
 		}
 
-		return s.Store.SetConfirm(name, content.Bytes(), "Read secret from STDIN", s.confirmRecipients)
+		return s.Store.SetConfirm(name, content.Bytes(), "Read secret from STDIN", confirm)
 	}
 
 	replacing, err := s.Store.Exists(name)
@@ -54,7 +58,7 @@ func (s *Action) Insert(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		return s.Store.SetConfirm(name, []byte(content), fmt.Sprintf("Inserted user supplied password with %s", os.Getenv("EDITOR")), s.confirmRecipients)
+		return s.Store.SetConfirm(name, []byte(content), fmt.Sprintf("Inserted user supplied password with %s", os.Getenv("EDITOR")), confirm)
 	}
 
 	// if echo mode is requested use a simple string input function
@@ -70,5 +74,5 @@ func (s *Action) Insert(c *cli.Context) error {
 		return fmt.Errorf("failed to ask for password: %v", err)
 	}
 
-	return s.Store.SetConfirm(name, []byte(content), "Inserted user supplied password", s.confirmRecipients)
+	return s.Store.SetConfirm(name, []byte(content), "Inserted user supplied password", confirm)
 }

--- a/main.go
+++ b/main.go
@@ -298,7 +298,7 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "force, f",
-					Usage: "Overwrite any existing secret",
+					Usage: "Overwrite any existing secret and do not prompt to confirm recipients",
 				},
 			},
 		},


### PR DESCRIPTION
This makes it easier to write an automated import script from other
password managers. In particular, I tried replacing pass with gopass in

https://git.zx2c4.com/password-store/tree/contrib/importers/lastpass2pass.rb

and it failed because it got an EOF at the Y/n query. With this change
and an added -f option in the script I could import a lastpass file.