### PR TITLE
Fix for "Failed to restore terminal: errno 0"

### DIFF
--- a/action/clihelper.go
+++ b/action/clihelper.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/justwatchcom/gopass/gpg"
 	"golang.org/x/crypto/ssh/terminal"
@@ -188,7 +189,11 @@ func promptPass(prompt string) (pass string, err error) {
 	}
 	defer func() {
 		if err := terminal.Restore(fd, oldState); err != nil {
-			fmt.Printf("Failed to restore terminal: %s\n", err)
+			if e, ok := err.(syscall.Errno); ok {
+				if e != 0 {
+					fmt.Printf("Failed to restore terminal: %s\n", err)
+				}
+			}
 		}
 	}()
 
@@ -198,7 +203,11 @@ func promptPass(prompt string) (pass string, err error) {
 	go func() {
 		for range sigch {
 			if err := terminal.Restore(fd, oldState); err != nil {
-				fmt.Printf("Failed to restore terminal: %s\n", err)
+				if e, ok := err.(syscall.Errno); ok {
+					if e != 0 {
+						fmt.Printf("Failed to restore terminal: %s\n", err)
+					}
+				}
 			}
 			os.Exit(1)
 		}


### PR DESCRIPTION
Aka: Handle borked return value for terminal.Restore

Until recently (go 1.8 still seems to be doing it the old way) `terminal.Restore` returned an error that was non-go-like.

This resulted in this error message whenever the terminal was set to no-echo and then restored:

> Failed to restore terminal: errno 0

This error has been reported in #13 and #39 (and perhaps others).

`terminal.Restore` has actually been returning the `syscall.Errno` returned by `syscall.Syscall6(..)`.  When it's 0 everything was successful, otherwise there's a problem.

`terminal.Restore` is returning it as a value of type `error`, which makes it hard to test for zero-ness.

This inconsistent behavior has been [fixed in this commit][fix].  I still see this problem when I build gopass with go@1.8, so apparently the [fix] did not make the cutoff.  I'm not sure how to code something that will work consistently with the pre- and post-correction versions of terminal.Restore().

[fix]: https://github.com/golang/crypto/commit/c3b1d0d6d8690eaebe3064711b026770cc37efa3