### PR TITLE
Make `-c` clip *all* the secret, not first line

### DIFF
--- a/action/show.go
+++ b/action/show.go
@@ -23,7 +23,7 @@ func (s *Action) Show(c *cli.Context) error {
 	}
 
 	if clip || qr {
-		content, err := s.Store.First(name)
+		content, err := s.Store.Get(name)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
If you create a multiline secret using e.g. `gopass edit` and then show
it, you see all of the lines.

If you copy it to the clipboard via `-c`, only the first line gets
copied to the clipboard.

This makes with and without `-c` behave identically.