### PR TITLE
Improve mounts and init commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ A second parameter tells gopass to clone and mount it to the store.
 In the example above the repository would have been cloned to `$HOME/.password-store-work`.
 Afterwards the directory would have been mounted as `work`.
 
+Please note that the repository must contain an already initialized password
+store. You can initialize a new store with `gopass init --store /path/to/store`.
+
 ### Adding secrets
 
 Let's say you want to create an account.
@@ -207,15 +210,17 @@ Mounting new stores can be done through gopass:
 
 ```bash
 # Mount a new store
-$ gopass mount test /tmp/password-store-test
+$ gopass mounts add test /tmp/password-store-test
 # Show mounted stores
-$ gopass mount
+$ gopass mounts
 # Umount a store
-$ gopass mount -u test
+$ gopass mounts remove test
 ```
 
 **WARNING**: Initializing new stores while mounting is currently not possible.
 For the time-being you can only mount existing stores.
+
+You can initialize a new store using `gopass init --store /path/to/store`.
 
 ### Edit the Config
 

--- a/action/clone.go
+++ b/action/clone.go
@@ -40,15 +40,15 @@ func (s *Action) Clone(c *cli.Context) error {
 		if !s.Store.Initialized() {
 			return fmt.Errorf("Root-Store is not initialized. Clone or init root store first")
 		}
-		fmt.Printf("Mounting password store %s at mount point `%s` ...\n", path, mount)
 		if err := s.Store.AddMount(mount, path); err != nil {
-			return err
+			return fmt.Errorf("Failed to add mount: %s", err)
 		}
+		fmt.Printf("Mounted password store %s at mount point `%s` ...\n", path, mount)
 	}
 
 	// save new mount in config file
 	if err := writeConfig(s.Store); err != nil {
-		return err
+		return fmt.Errorf("Failed to update config: %s", err)
 	}
 
 	fmt.Printf("Your password store is ready to use! Has a look around: `gopass %s`\n", mount)

--- a/action/init.go
+++ b/action/init.go
@@ -32,10 +32,13 @@ func (s *Action) Init(c *cli.Context) error {
 		s.Store.LoadKeys = false
 		s.Store.ClipTimeout = 45
 	}
+	if store == "" {
+		store = s.Store.Path
+	}
 
 	keys := c.Args()
 	if len(keys) < 1 {
-		nk, err := askForPrivateKey("Please select a private Key for encryption:")
+		nk, err := askForPrivateKey("Please select a private key for encryption:")
 		if err != nil {
 			return err
 		}

--- a/password/root_store.go
+++ b/password/root_store.go
@@ -123,8 +123,12 @@ func (r *RootStore) Initialized() bool {
 }
 
 // Init tries to initalize a new password store location matching the object
-func (r *RootStore) Init(store string, ids ...string) error {
-	sub := r.getStore(store)
+func (r *RootStore) Init(path string, ids ...string) error {
+	sub, err := NewStore("", fsutil.CleanPath(path), r)
+	if err != nil {
+		return err
+	}
+
 	sub.persistKeys = r.PersistKeys
 	sub.loadKeys = r.LoadKeys
 	sub.alwaysTrust = r.AlwaysTrust
@@ -166,7 +170,7 @@ func (r *RootStore) addMount(alias, path string, keys ...string) error {
 
 	if !s.Initialized() {
 		if len(keys) < 1 {
-			return fmt.Errorf("password store %s is not initialized. Try gopass init", path)
+			return fmt.Errorf("password store %s is not initialized. Try gopass init --store %s", alias, path)
 		}
 		if err := s.Init(keys...); err != nil {
 			return err


### PR DESCRIPTION
This commit adds an option to init new stores at arbitrary locations
using gopass init --store /path.

It also tries to clarify the existing mount and clone behaviour.

Fixes #75