### PR TITLE
Improve recursive deletes

### DIFF
--- a/password/git.go
+++ b/password/git.go
@@ -134,6 +134,9 @@ func (s *Store) gitAdd(files ...string) error {
 	if !s.isGit() {
 		return ErrGitNotInit
 	}
+	for i := range files {
+		files[i] = strings.TrimPrefix(files[i], s.path+"/")
+	}
 
 	args := []string{"add", "--all"}
 	args = append(args, files...)

--- a/password/store.go
+++ b/password/store.go
@@ -400,16 +400,17 @@ func (s *Store) Prune(tree string) error {
 func (s *Store) delete(name string, recurse bool) error {
 	path := s.passfile(name)
 	rf := os.Remove
-	if recurse {
-		path = filepath.Join(s.path, name)
-		rf = os.RemoveAll
-	}
 
 	if !recurse && !fsutil.IsFile(path) {
 		return ErrNotFound
 	}
-	if recurse && !fsutil.IsDir(path) {
-		return ErrNotFound
+
+	if recurse && !fsutil.IsFile(path) {
+		path = filepath.Join(s.path, name)
+		rf = os.RemoveAll
+		if !fsutil.IsDir(path) {
+			return ErrNotFound
+		}
 	}
 
 	if err := rf(path); err != nil {


### PR DESCRIPTION
This commit improves handling of 'rm -r' on files as well as
removing empty dirs.

Fixes #55
Fixes #70 

This will need some testing before release, as it may change `rm` in subtle ways.