### PR TITLE
Use go 1.8.x to build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - 1.8.x
   - tip
 
 before_install:


### PR DESCRIPTION
See https://github.com/prometheus/prometheus/pull/2568 for why I changed this.