### PR TITLE
specify end of flags for xdotool

### DIFF
--- a/action/completion.go
+++ b/action/completion.go
@@ -84,7 +84,7 @@ func (s *Action) CompletionDMenu(c *cli.Context) error {
 	}
 
 	if typeit {
-		return exec.Command("xdotool", "type", "--clearmodifiers", string(content)).Run()
+		return exec.Command("xdotool", "type", "--clearmodifiers", "--", string(content)).Run()
 	}
 
 	return s.copyToClipboard(name, content)


### PR DESCRIPTION
We don't want passwords starting with a dash to be interpreted as xdotool arguments