### PR TITLE
Enforce UNIX style line endings in the password store

### DIFF
--- a/action/edit.go
+++ b/action/edit.go
@@ -90,5 +90,9 @@ func (s *Action) editor(content []byte) ([]byte, error) {
 		return []byte{}, fmt.Errorf("failed to read from tmpfile: %v", err)
 	}
 
+	// enforce unix line endings in the password store
+	nContent = bytes.Replace(nContent, []byte("\r\n"), []byte("\n"), -1)
+	nContent = bytes.Replace(nContent, []byte("\r"), []byte("\n"), -1)
+
 	return nContent, nil
 }


### PR DESCRIPTION
This PR enforces UNIX style line endings (`\n`) when using `gopass edit`.

Not sure if we should enforce this in other places as well, but we need to be careful around binary data.