### PR TITLE
Add support for YAML metadata parsing

### DIFF
--- a/action/show.go
+++ b/action/show.go
@@ -1,7 +1,6 @@
 package action
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/atotto/clipboard"
@@ -32,8 +31,8 @@ func (s *Action) Show(c *cli.Context) error {
 		return err
 	}
 
-	// if we only want to display safe contnt or if we want parse the secret as yaml strip the first line
-	if (s.Store.SafeContent && !force) || key != "" {
+	// load metadata if we want to parse the YAML (key is given) or we only want to display safe content (=metadata) and no clip/qr flag is given
+	if key != "" || (s.Store.SafeContent && !force && !(clip || qr)) {
 		content, err = s.Store.Metadata(name)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -416,6 +416,10 @@ func main() {
 					Name:  "force, f",
 					Usage: "Display the password even if safecontent is enabled",
 				},
+				cli.StringFlag{
+					Name:  "key, k",
+					Usage: "Load secret metadata as YAML and display a single key",
+				},
 			},
 		},
 		{

--- a/password/root_store.go
+++ b/password/root_store.go
@@ -325,6 +325,19 @@ func (r *RootStore) First(name string) ([]byte, error) {
 	return bytes.TrimSpace(lines[0]), nil
 }
 
+// Metadata returns the content of a single entry except of the first line (the password)
+func (r *RootStore) Metadata(name string) ([]byte, error) {
+	content, err := r.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	lines := bytes.SplitN(content, []byte("\n"), 2)
+	if len(lines) < 2 || len(bytes.TrimSpace(lines[1])) == 0 {
+		return nil, fmt.Errorf("no safe content to display, you can force display with show -f")
+	}
+	return lines[1], nil
+}
+
 // Exists checks the existence of a single entry
 func (r *RootStore) Exists(name string) (bool, error) {
 	store := r.getStore(name)

--- a/password/root_store.go
+++ b/password/root_store.go
@@ -333,7 +333,7 @@ func (r *RootStore) Metadata(name string) ([]byte, error) {
 	}
 	lines := bytes.SplitN(content, []byte("\n"), 2)
 	if len(lines) < 2 || len(bytes.TrimSpace(lines[1])) == 0 {
-		return nil, fmt.Errorf("no safe content to display, you can force display with show -f")
+		return nil, fmt.Errorf("no metadata found")
 	}
 	return lines[1], nil
 }


### PR DESCRIPTION
This allows loading a specified key from a as yaml formatted metadata part of a secret. (related issue: #112 )

## Usage: 

assuming the following secret:

```
password

yaml: mammal
name: Johne Doe
```

### Display the value of a specified key:
```bash
gopass show yaml-example --key [yaml key]
```
### Copy the value of a specified key:
```bash
gopass show yaml-example -k [yaml key] -c 
```

When the `-k/--key` option is given the first line (the password) of a secret will be ignored and the rest will be loaded using [simpleyaml](https://github.com/smallfish/simpleyaml/). The `--clip` and `--qr` flags are still supported and the value the `--key` will be used. 

Editing the metadata part is currently not supported. In my usecase editing would mostly be manual and yaml is easy enough to write. So I don't think that this is super important. 

I am opening this PR for discussion on how this feature should be implemented. 
This is my first piece of go code that I am writing... so I don't really know what I am doing yet :) 

## ToDo:

- [ ] support any type of value in the YAML (currently strings are assumed) 
