### PR TITLE
Improve error message in case the directory to clone to already exists

### DIFF
--- a/action/clone.go
+++ b/action/clone.go
@@ -58,7 +58,7 @@ func (s *Action) Clone(c *cli.Context) error {
 
 func gitClone(repo, path string) error {
 	if fsutil.IsDir(path) {
-		return fmt.Errorf("%s is a directory", path)
+		return fmt.Errorf("%s is a directory that already exists", path)
 	}
 
 	fmt.Printf("Cloning repository %s to %s ...\n", repo, path)


### PR DESCRIPTION
Trying `gopass clone --path` the first time, we were surprised by the error message: "~/foo is a directory? - yes, thats where we want to clone to!". 

This PR tries to make it a bit more clear what happens: that gopass expects a path that doesn't exist so it can create it.