### PR TITLE
Sync config using reflection to avoid missing added/changed fields

### DIFF
--- a/store/root/config_test.go
+++ b/store/root/config_test.go
@@ -1,0 +1,46 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/justwatchcom/gopass/config"
+)
+
+func TestConfig(t *testing.T) {
+	s := &Store{
+		autoPush:    true,
+		clipTimeout: 10,
+		path:        "/tmp/two",
+	}
+	cfg := s.Config()
+
+	if !cfg.AutoPush {
+		t.Errorf("AutoPush should be true")
+	}
+	if cfg.ClipTimeout != 10 {
+		t.Errorf("ClipTimeout should be 10")
+	}
+	if cfg.Path != "/tmp/two" {
+		t.Errorf("Path should be /tmp/two")
+	}
+}
+
+func TestUpdateConfig(t *testing.T) {
+	s := &Store{}
+	if err := s.UpdateConfig(&config.Config{
+		Path:        "/tmp/foo",
+		NoConfirm:   true,
+		ClipTimeout: 23,
+	}); err != nil {
+		t.Fatalf("Failed to update config: %s", err)
+	}
+	if s.Path() != "/tmp/foo" {
+		t.Errorf("Wrong value for path")
+	}
+	if !s.NoConfirm() {
+		t.Errorf("Wrong value for NoConfirm")
+	}
+	if s.ClipTimeout() != 23 {
+		t.Errorf("Wrong clip timeout")
+	}
+}

--- a/store/root/store.go
+++ b/store/root/store.go
@@ -46,26 +46,14 @@ func New(cfg *config.Config) (*Store, error) {
 		return nil, fmt.Errorf("need path")
 	}
 	r := &Store{
-		alwaysTrust: cfg.AlwaysTrust,
-		askForMore:  cfg.AskForMore,
-		autoImport:  cfg.AutoImport,
-		autoPull:    cfg.AutoPull,
-		autoPush:    cfg.AutoPush,
-		clipTimeout: cfg.ClipTimeout,
-		debug:       cfg.Debug,
-		fsckFunc:    cfg.FsckFunc,
 		gpg: gpg.New(gpg.Config{
 			Debug:       cfg.Debug,
 			AlwaysTrust: cfg.AlwaysTrust,
 		}),
-		importFunc:  cfg.ImportFunc,
-		loadKeys:    cfg.LoadKeys,
-		mounts:      make(map[string]*sub.Store, len(cfg.Mounts)),
-		noColor:     cfg.NoColor,
-		noConfirm:   cfg.NoConfirm,
-		path:        cfg.Path,
-		persistKeys: cfg.PersistKeys,
-		safeContent: cfg.SafeContent,
+		mounts: make(map[string]*sub.Store, len(cfg.Mounts)),
+	}
+	if err := r.UpdateConfig(cfg); err != nil {
+		return nil, err
 	}
 
 	if r.autoImport {

--- a/store/sub/config.go
+++ b/store/sub/config.go
@@ -2,6 +2,9 @@ package sub
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
+	"unsafe"
 
 	"github.com/justwatchcom/gopass/config"
 )
@@ -9,18 +12,37 @@ import (
 // Config returns this sub stores config as a config struct
 func (s *Store) Config() *config.Config {
 	c := &config.Config{
-		AlwaysTrust: s.alwaysTrust,
-		AutoImport:  s.autoImport,
-		AutoPull:    s.autoPull,
-		AutoPush:    s.autoPush,
-		Debug:       s.debug,
-		FsckFunc:    s.fsckFunc,
-		ImportFunc:  s.importFunc,
-		LoadKeys:    s.loadKeys,
-		Mounts:      make(map[string]string),
-		Path:        s.path,
-		PersistKeys: s.persistKeys,
+		Mounts: make(map[string]string),
 	}
+
+	c.FsckFunc = s.fsckFunc
+	c.ImportFunc = s.importFunc
+
+	os := reflect.ValueOf(s).Elem()
+	oc := reflect.ValueOf(c).Elem()
+	for i := 0; i < os.NumField(); i++ {
+		gpArg := os.Type().Field(i).Tag.Get("gopass")
+		if gpArg == "-" {
+			continue
+		}
+		fs := os.Field(i)
+		name := strings.Title(os.Type().Field(i).Name)
+		fc := oc.FieldByName(name)
+		if fc.Kind() != fs.Kind() {
+			continue
+		}
+		switch fs.Kind() {
+		case reflect.String:
+			fc.SetString(fs.String())
+		case reflect.Bool:
+			fc.SetBool(fs.Bool())
+		case reflect.Int:
+			fc.SetInt(fs.Int())
+		default:
+			continue
+		}
+	}
+
 	return c
 }
 
@@ -29,17 +51,42 @@ func (s *Store) UpdateConfig(cfg *config.Config) error {
 	if cfg == nil {
 		return fmt.Errorf("invalid config")
 	}
-	s.alwaysTrust = cfg.AlwaysTrust
-	s.autoImport = cfg.AutoImport
-	s.autoPull = cfg.AutoPull
-	s.autoPush = cfg.AutoPush
-	s.debug = cfg.Debug
+
 	s.fsckFunc = cfg.FsckFunc
 	s.importFunc = cfg.ImportFunc
-	s.loadKeys = cfg.LoadKeys
-	s.path = cfg.Path
-	s.persistKeys = cfg.PersistKeys
 
+	os := reflect.ValueOf(s).Elem()
+	oc := reflect.ValueOf(cfg).Elem()
+	for i := 0; i < os.NumField(); i++ {
+		gpArg := os.Type().Field(i).Tag.Get("gopass")
+		if gpArg == "-" {
+			continue
+		}
+		fs := os.Field(i)
+		name := strings.Title(os.Type().Field(i).Name)
+		fc := oc.FieldByName(name)
+		if fc.Kind() != fs.Kind() {
+			continue
+		}
+		if !fs.CanAddr() {
+			continue
+		}
+		// Acording to the "rules of reflect" fields obtained through unexported
+		// fields can not be updated. The following line creates a writeable
+		// copy at the exact same location to make it writeable.
+		// see https://stackoverflow.com/a/43918797/218846
+		fs = reflect.NewAt(fs.Type(), unsafe.Pointer(fs.UnsafeAddr())).Elem()
+		switch fc.Kind() {
+		case reflect.String:
+			fs.SetString(fc.String())
+		case reflect.Bool:
+			fs.SetBool(fc.Bool())
+		case reflect.Int:
+			fs.SetInt(fc.Int())
+		default:
+			continue
+		}
+	}
 	// substores have no mounts
 
 	return nil

--- a/store/sub/config_test.go
+++ b/store/sub/config_test.go
@@ -1,0 +1,35 @@
+package sub
+
+import (
+	"testing"
+
+	"github.com/justwatchcom/gopass/config"
+)
+
+func TestConfig(t *testing.T) {
+	s := &Store{
+		autoPush: true,
+		path:     "/tmp/two",
+	}
+	cfg := s.Config()
+
+	if !cfg.AutoPush {
+		t.Errorf("AutoPush should be true")
+	}
+	if cfg.Path != "/tmp/two" {
+		t.Errorf("Path should be /tmp/two")
+	}
+}
+
+func TestUpdateConfig(t *testing.T) {
+	s := &Store{}
+	if err := s.UpdateConfig(&config.Config{
+		AutoPush: true,
+		Path:     "/tmp/foo",
+	}); err != nil {
+		t.Fatalf("Failed to update config: %s", err)
+	}
+	if s.Path() != "/tmp/foo" {
+		t.Errorf("Wrong value for path")
+	}
+}


### PR DESCRIPTION
This PR overhauls the way we sync config changes between the different components of gopass. It's a little _technical_, but I think it make future changes easier.

There is some duplication in the code due to the way how reflect works with unexported fields ...