### PR TITLE
Implement binary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,23 @@ We also support `pull before push` to reduce the change of `rejected` pushes whe
 $ gopass config autopull true
 ```
 
+### Support for Binary Content
+
+gopass provides secure and easy support for working with binary files through the
+`gopass binary` family of subcommands. One can copy or move secret from or to
+the store. gopass will attempt to securely overwrite and remove any secret moved
+to the store.
+
+```bash
+# copy file "/some/file.jpg" to "some/secret.b64" in the store
+$ gopass binary cp /some/file.jpg some/secret
+# move file "/home/user/private.key" to "my/private.key.b64", removing the file on disk
+# after the file has been encoded, stored and verified to be intact (SHA256)
+$ gopass binary mv /home/user/private.key my/private.key
+# Calculate the checksum of some asset
+$ gopass binary sha256 my/private.key
+```
+
 ### Multiple Stores
 
 gopass supports multi-stores that can be mounted over each other like filesystems
@@ -556,8 +573,8 @@ If you use `gopass` as a library be sure to vendor it and expect breaking change
 
 ## Roadmap
 
-- [x] Be 100% pass 1.6.5 compatible
-- [ ] Storing binary files in gopass (almost done)
+- [x] Be 100% pass 1.4 compatible
+- [x] Storing binary files in gopass (almost done)
 - [x] Storing structured files and templates (credit cards, DBs, websites...)
 - [ ] UX improvements and more wizards
 - [ ] Tackle the information disclosure issue

--- a/action/binary.go
+++ b/action/binary.go
@@ -1,0 +1,185 @@
+package action
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/justwatchcom/gopass/fsutil"
+	"github.com/urfave/cli"
+)
+
+const (
+	// BinarySuffix is the suffix that is appended to binaries in the store
+	BinarySuffix = ".b64"
+)
+
+// BinaryCat prints to or reads from STDIN/STDOUT
+func (s *Action) BinaryCat(c *cli.Context) error {
+	name := c.Args().First()
+	if name == "" {
+		return fmt.Errorf("need a name")
+	}
+	if !strings.HasSuffix(name, BinarySuffix) {
+		name += BinarySuffix
+	}
+
+	// handle pipe to stdin
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return fmt.Errorf("Failed to stat stdin: %s", err)
+	}
+	// if content is piped to stdin, read and save it
+	if info.Mode()&os.ModeCharDevice == 0 {
+		content := &bytes.Buffer{}
+
+		if written, err := io.Copy(content, os.Stdin); err != nil {
+			return fmt.Errorf("Failed to copy after %d bytes: %s", written, err)
+		}
+
+		return s.Store.Set(name, []byte(base64.StdEncoding.EncodeToString(content.Bytes())), "Read secret from STDIN")
+	}
+
+	buf, err := s.binaryGet(name)
+	if err != nil {
+		return err
+	}
+	color.Yellow(string(buf))
+	return nil
+}
+
+// BinarySum decodes binary content and computes the SHA256 checksum
+func (s *Action) BinarySum(c *cli.Context) error {
+	name := c.Args().First()
+	if !strings.HasSuffix(name, BinarySuffix) {
+		name += BinarySuffix
+	}
+	buf, err := s.binaryGet(name)
+	if err != nil {
+		return err
+	}
+	h := sha256.New()
+	_, _ = h.Write(buf)
+	color.Yellow("%x", h.Sum(nil))
+	return nil
+}
+
+// BinaryCopy copies either from the filesystem to the store or from the store
+// to the filesystem
+func (s *Action) BinaryCopy(c *cli.Context) error {
+	from := c.Args().Get(0)
+	to := c.Args().Get(1)
+
+	return s.binaryCopy(from, to, false)
+}
+
+// BinaryMove works like BinaryCopy but will remove (shred/wipe) the source
+// after a successfull copy. Mostly useful for securely moving secrets into
+// the store if they are no longer needed / wanted on disk afterwards
+func (s *Action) BinaryMove(c *cli.Context) error {
+	from := c.Args().Get(0)
+	to := c.Args().Get(1)
+
+	return s.binaryCopy(from, to, true)
+}
+
+// binaryCopy implements the control flow for copy and move. We support two
+// workflows:
+// 1. From the filesystem to the store
+// 2. From the store to the filesystem
+//
+// Copying secrets in the store must be done through the regular copy command
+func (s *Action) binaryCopy(from, to string, deleteSource bool) error {
+	switch {
+	case fsutil.IsFile(from) && fsutil.IsFile(to):
+		// copying from on file to another file is not supported
+		return fmt.Errorf("ambiquity detected. Only from or to can a file")
+	case s.Store.Exists(from) && s.Store.Exists(to):
+		// copying from one secret to another secret is not supported
+		return fmt.Errorf("ambiquity detected. Either from or to must be a file")
+	case fsutil.IsFile(from) && !fsutil.IsFile(to):
+		// if the source is a file the destination must no to avoid ambiquities
+		// if necessary this can be resolved by using a absolute path for the file
+		// and a relative one for the secret
+		if !strings.HasSuffix(to, BinarySuffix) {
+			to += BinarySuffix
+		}
+		// copy from FS to store
+		buf, err := ioutil.ReadFile(from)
+		if err != nil {
+			return err
+		}
+		if err := s.Store.Set(to, []byte(base64.StdEncoding.EncodeToString(buf)), fmt.Sprintf("Copied data from %s to %s", from, to)); err != nil {
+			return err
+		}
+		if deleteSource {
+			if err := s.binaryValidate(buf, to); err != nil {
+				return err
+			}
+			return fsutil.Shred(from, 8)
+		}
+		return nil
+	case !fsutil.IsFile(from):
+		// if the source is no file we assume it's a secret and to is a filename
+		// (which may already exist or not)
+		if !strings.HasSuffix(from, BinarySuffix) {
+			from += BinarySuffix
+		}
+		// copy from store to FS
+		buf, err := s.binaryGet(from)
+		if err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(to, buf, 0600); err != nil {
+			return err
+		}
+		if deleteSource {
+			if err := s.binaryValidate(buf, from); err != nil {
+				return err
+			}
+			return s.Store.Delete(from)
+		}
+		return nil
+	default:
+		return fmt.Errorf("ambiquity detected. Unhandled case. Please report a bug")
+	}
+}
+
+func (s *Action) binaryValidate(buf []byte, name string) error {
+	h := sha256.New()
+	_, _ = h.Write(buf)
+	fileSum := fmt.Sprintf("%x", h.Sum(nil))
+
+	h.Reset()
+
+	var err error
+	buf, err = s.binaryGet(name)
+	if err != nil {
+		return err
+	}
+	_, _ = h.Write(buf)
+	storeSum := fmt.Sprintf("%x", h.Sum(nil))
+
+	if fileSum != storeSum {
+		return fmt.Errorf("Hashsum mismatch (file: %s, store: %s)", fileSum, storeSum)
+	}
+	return nil
+}
+
+func (s *Action) binaryGet(name string) ([]byte, error) {
+	buf, err := s.Store.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	buf, err = base64.StdEncoding.DecodeString(string(buf))
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/action/copy.go
+++ b/action/copy.go
@@ -17,21 +17,12 @@ func (s *Action) Copy(c *cli.Context) error {
 	from := c.Args()[0]
 	to := c.Args()[1]
 
-	exists, err := s.Store.Exists(from)
-	if err != nil {
-		return err
-	}
-
-	if !exists {
+	if !s.Store.Exists(from) {
 		return fmt.Errorf("%s doesn't exists", from)
 	}
 
 	if !force {
-		exists, err := s.Store.Exists(to)
-		if err != nil {
-			return err
-		}
-		if exists && !askForConfirmation(fmt.Sprintf("%s already exists. Overwrite it?", to)) {
+		if s.Store.Exists(to) && !askForConfirmation(fmt.Sprintf("%s already exists. Overwrite it?", to)) {
 			return fmt.Errorf("not overwriting your current secret")
 		}
 	}

--- a/action/delete.go
+++ b/action/delete.go
@@ -3,7 +3,6 @@ package action
 import (
 	"fmt"
 
-	"github.com/justwatchcom/gopass/store"
 	"github.com/urfave/cli"
 )
 
@@ -17,17 +16,12 @@ func (s *Action) Delete(c *cli.Context) error {
 		return fmt.Errorf("provide a secret name")
 	}
 
-	found, err := s.Store.Exists(name)
-	if err != nil && err != store.ErrNotFound {
-		return fmt.Errorf("failed to see if %s exists", name)
-	}
-
 	if !force { // don't check if it's force anyway
 		recStr := ""
 		if recursive {
 			recStr = "recursively "
 		}
-		if found && !askForConfirmation(fmt.Sprintf("Are you sure you would like to %sdelete %s?", recStr, name)) {
+		if s.Store.Exists(name) && !askForConfirmation(fmt.Sprintf("Are you sure you would like to %sdelete %s?", recStr, name)) {
 			return nil
 		}
 	}

--- a/action/edit.go
+++ b/action/edit.go
@@ -10,7 +10,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/fsutil"
 	"github.com/justwatchcom/gopass/pwgen"
-	"github.com/justwatchcom/gopass/store"
 	"github.com/justwatchcom/gopass/tpl"
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/urfave/cli"
@@ -23,14 +22,10 @@ func (s *Action) Edit(c *cli.Context) error {
 		return fmt.Errorf("provide a secret name")
 	}
 
-	exists, err := s.Store.Exists(name)
-	if err != nil && err != store.ErrNotFound {
-		return fmt.Errorf("failed to see if %s exists", name)
-	}
-
 	var content []byte
 	var changed bool
-	if exists {
+	if s.Store.Exists(name) {
+		var err error
 		content, err = s.Store.Get(name)
 		if err != nil {
 			return fmt.Errorf("failed to decrypt %s: %v", name, err)

--- a/action/generate.go
+++ b/action/generate.go
@@ -29,13 +29,8 @@ func (s *Action) Generate(c *cli.Context) error {
 		}
 	}
 
-	replacing, err := s.Store.Exists(name)
-	if err != nil {
-		return fmt.Errorf("failed to see if %s exists: %s", name, err)
-	}
-
 	if !force { // don't check if it's force anyway
-		if replacing && !askForConfirmation(fmt.Sprintf("An entry already exists for %s. Overwrite it?", name)) {
+		if s.Store.Exists(name) && !askForConfirmation(fmt.Sprintf("An entry already exists for %s. Overwrite it?", name)) {
 			return fmt.Errorf("not overwriting your current password")
 		}
 	}

--- a/action/insert.go
+++ b/action/insert.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/justwatchcom/gopass/store"
 	"github.com/urfave/cli"
 )
 
@@ -55,13 +54,8 @@ func (s *Action) Insert(c *cli.Context) error {
 		return s.Store.SetConfirm(name, content.Bytes(), "Read secret from STDIN", confirm)
 	}
 
-	replacing, err := s.Store.Exists(name)
-	if err != nil && err != store.ErrNotFound {
-		return fmt.Errorf("failed to see if %s exists", name)
-	}
-
 	if !force { // don't check if it's force anyway
-		if replacing && !askForConfirmation(fmt.Sprintf("An entry already exists for %s. Overwrite it?", name)) {
+		if s.Store.Exists(name) && !askForConfirmation(fmt.Sprintf("An entry already exists for %s. Overwrite it?", name)) {
 			return fmt.Errorf("not overwriting your current secret")
 		}
 	}

--- a/action/move.go
+++ b/action/move.go
@@ -18,11 +18,7 @@ func (s *Action) Move(c *cli.Context) error {
 	to := c.Args()[1]
 
 	if !force {
-		exists, err := s.Store.Exists(to)
-		if err != nil {
-			return err
-		}
-		if exists && !askForConfirmation(fmt.Sprintf("%s already exists. Overwrite it?", to)) {
+		if s.Store.Exists(to) && !askForConfirmation(fmt.Sprintf("%s already exists. Overwrite it?", to)) {
 			return fmt.Errorf("not overwriting your current secret")
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -92,6 +92,56 @@ func main() {
 
 	app.Commands = []cli.Command{
 		{
+			Name:    "binary",
+			Usage:   "Work with binary blobs",
+			Aliases: []string{"bin"},
+			Subcommands: []cli.Command{
+				{
+					Name:         "cat",
+					Usage:        "Print content of a secret to stdout or insert from stdin",
+					Before:       action.Initialized,
+					Action:       action.BinaryCat,
+					BashComplete: action.Complete,
+				},
+				{
+					Name:         "sum",
+					Usage:        "Compute the SHA256 sum of a decoded secret",
+					Aliases:      []string{"sha", "sha256"},
+					Before:       action.Initialized,
+					Action:       action.BinarySum,
+					BashComplete: action.Complete,
+				},
+				{
+					Name:         "copy",
+					Usage:        "Copy files from or to the password store",
+					Before:       action.Initialized,
+					Aliases:      []string{"cp"},
+					Action:       action.BinaryCopy,
+					BashComplete: action.Complete,
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "force, f",
+							Usage: "Force to move the secret and overwrite existing one",
+						},
+					},
+				},
+				{
+					Name:         "move",
+					Usage:        "Move files from or to the password store",
+					Before:       action.Initialized,
+					Aliases:      []string{"mv"},
+					Action:       action.BinaryMove,
+					BashComplete: action.Complete,
+					Flags: []cli.Flag{
+						cli.BoolFlag{
+							Name:  "force, f",
+							Usage: "Force to move the secret and overwrite existing one",
+						},
+					},
+				},
+			},
+		},
+		{
 			Name:        "clone",
 			Usage:       "Clone a new store",
 			Description: "To clone a remote repo",

--- a/store/root/store.go
+++ b/store/root/store.go
@@ -217,7 +217,7 @@ func (r *Store) GetBody(name string) ([]byte, error) {
 }
 
 // Exists checks the existence of a single entry
-func (r *Store) Exists(name string) (bool, error) {
+func (r *Store) Exists(name string) bool {
 	store := r.getStore(name)
 	return store.Exists(strings.TrimPrefix(name, store.Alias()))
 }

--- a/store/sub/store.go
+++ b/store/sub/store.go
@@ -231,14 +231,14 @@ func (s *Store) IsDir(name string) bool {
 }
 
 // Exists checks the existence of a single entry
-func (s *Store) Exists(name string) (bool, error) {
+func (s *Store) Exists(name string) bool {
 	p := s.passfile(name)
 
 	if !strings.HasPrefix(p, s.path) {
-		return false, store.ErrSneaky
+		return false
 	}
 
-	return fsutil.IsFile(p), nil
+	return fsutil.IsFile(p)
 }
 
 // Set encodes and write the ciphertext of one entry to disk
@@ -316,7 +316,7 @@ func (s *Store) SetConfirm(name string, content []byte, reason string, cb store.
 func (s *Store) Copy(from, to string) error {
 	// recursive copy?
 	if s.IsDir(from) {
-		if found, err := s.Exists(to); err != nil || found {
+		if s.Exists(to) {
 			return fmt.Errorf("Can not copy dir to file")
 		}
 		sf, err := s.List("")
@@ -355,7 +355,7 @@ func (s *Store) Copy(from, to string) error {
 func (s *Store) Move(from, to string) error {
 	// recursive move?
 	if s.IsDir(from) {
-		if found, err := s.Exists(to); err != nil || found {
+		if s.Exists(to) {
 			return fmt.Errorf("Can not move dir to file")
 		}
 		sf, err := s.List("")

--- a/tests/uninitialized_test.go
+++ b/tests/uninitialized_test.go
@@ -12,7 +12,6 @@ func TestUninitialized(t *testing.T) {
 
 	commands := []string{
 		"",
-		"binary",
 		"copy",
 		"cp",
 		"delete",


### PR DESCRIPTION
This PR adds a binary command with several subcommands that streamline
working with binary data. To retain compatability with other password
managers the data is store base64 encoded.

We may want to add confirmation interaction for some of the destructive operations in the future, but right now I wanted to keep this PR to the point. Those can easily and cleanly added later on.