### PR TITLE
Collect test stati and report after checking all packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,25 +56,25 @@ lint:
 	@which golint > /dev/null; if [ $$? -ne 0 ]; then \
 		$(GO) get -u github.com/golang/lint/golint; \
 	fi
-	for PKG in $(PACKAGES); do golint -set_exit_status $$PKG || exit 1; done;
+	STATUS=0; for PKG in $(PACKAGES); do golint -set_exit_status $$PKG || STATUS=1; done; exit $$STATUS
 
 .PHONY: errcheck
 errcheck:
 	@which errcheck > /dev/null; if [ $$? -ne 0 ]; then \
 		$(GO) get -u github.com/kisielk/errcheck; \
 	fi
-	for PKG in $(PACKAGES); do errcheck $$PKG || exit 1; done;
+	STATUS=0; for PKG in $(PACKAGES); do errcheck $$PKG || STATUS=1; done; exit $$STATUS
 
 .PHONY: megacheck
 megacheck:
 	@which megacheck > /dev/null; if [ $$? -ne 0  ]; then \
 		$(GO) get -u honnef.co/go/tools/cmd/megacheck; \
 	fi
-	for PKG in $(PACKAGES); do megacheck $$PKG || exit 1; done;
+	STATUS=0; for PKG in $(PACKAGES); do megacheck $$PKG || STATUS=1; done; exit $$STATUS
 
 .PHONY: test
 test:
-	for PKG in $(PACKAGES); do go test -cover -coverprofile $$GOPATH/src/$$PKG/coverage.out $$PKG || exit 1; done;
+	STATUS=0; for PKG in $(PACKAGES); do go test -cover -coverprofile $$GOPATH/src/$$PKG/coverage.out $$PKG || STATUS=1; done; exit $$STATUS
 
 .PHONY: test-integration
 test-integration: clean build

--- a/qrcon/qrcon.go
+++ b/qrcon/qrcon.go
@@ -27,14 +27,14 @@ func QRCode(content string) (string, error) {
 		for y := b.Min.Y; y < b.Max.Y; y++ {
 			col := i.At(x, y)
 			if sameColor(col, q.ForegroundColor) {
-				buf.WriteString(black)
+				_, _ = buf.WriteString(black)
 			} else if sameColor(col, q.BackgroundColor) {
-				buf.WriteString(white)
+				_, _ = buf.WriteString(white)
 			} else {
 				return "", fmt.Errorf("Unexpected color at (%d,%d): %+v", x, y, col)
 			}
 		}
-		buf.WriteString("\n")
+		_, _ = buf.WriteString("\n")
 	}
 	return buf.String(), nil
 }


### PR DESCRIPTION
This PR changes the Makefile a bit to run the tests on all packages (instead of aboring after a failure) and report any error only at the end.

This make the tests a little more useable.