### PR TITLE
Refactor GPG package

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -18,6 +18,7 @@ import (
 type Action struct {
 	Name  string
 	Store *root.Store
+	gpg   *gpg.GPG
 }
 
 // New returns a new Action wrapper
@@ -27,11 +28,13 @@ func New(v string) *Action {
 		name = filepath.Base(os.Args[0])
 	}
 
+	// debug flag
 	debug := false
 	if gdb := os.Getenv("GOPASS_DEBUG"); gdb == "true" {
-		gpg.Debug = true
 		debug = true
 	}
+
+	// nocolorflag
 	noColor := false
 	// need this override for our integration tests
 	if nc := os.Getenv("GOPASS_NOCOLOR"); nc == "true" {
@@ -59,6 +62,10 @@ func New(v string) *Action {
 		return &Action{
 			Name:  name,
 			Store: store,
+			gpg: gpg.New(gpg.Config{
+				Debug:       debug,
+				AlwaysTrust: cfg.AlwaysTrust,
+			}),
 		}
 	}
 
@@ -76,6 +83,10 @@ func New(v string) *Action {
 	return &Action{
 		Name:  name,
 		Store: rs,
+		gpg: gpg.New(gpg.Config{
+			Debug:       debug,
+			AlwaysTrust: cfg.AlwaysTrust,
+		}),
 	}
 }
 

--- a/action/clihelper.go
+++ b/action/clihelper.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/justwatchcom/gopass/gpg"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -22,7 +21,7 @@ func (s *Action) confirmRecipients(name string, recipients []string) ([]string, 
 		fmt.Printf("gopass: Encrypting %s for these recipients:\n", name)
 		sort.Strings(recipients)
 		for _, r := range recipients {
-			kl, err := gpg.ListPublicKeys(r)
+			kl, err := s.gpg.FindPublicKeys(r)
 			if err != nil {
 				fmt.Println(err)
 				continue
@@ -154,8 +153,8 @@ func askForKeyImport(key string) bool {
 }
 
 // askforPrivateKey promts the user to select from a list of private keys
-func askForPrivateKey(prompt string) (string, error) {
-	kl, err := gpg.ListPrivateKeys()
+func (s *Action) askForPrivateKey(prompt string) (string, error) {
+	kl, err := s.gpg.ListPrivateKeys()
 	if err != nil {
 		return "", err
 	}

--- a/action/git.go
+++ b/action/git.go
@@ -23,7 +23,7 @@ func (s *Action) GitInit(c *cli.Context) error {
 
 func (s *Action) gitInit(store, sk string) error {
 	if sk == "" {
-		s, err := askForPrivateKey(color.CyanString("Please select a key for signing Git Commits"))
+		s, err := s.askForPrivateKey(color.CyanString("Please select a key for signing Git Commits"))
 		if err == nil {
 			sk = s
 		}

--- a/action/init.go
+++ b/action/init.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
-	"github.com/justwatchcom/gopass/gpg"
 	"github.com/urfave/cli"
 )
 
@@ -32,7 +31,7 @@ func (s *Action) init(alias, path string, nogit bool, keys ...string) error {
 	}
 
 	if len(keys) < 1 {
-		nk, err := askForPrivateKey(color.CyanString("Please select a private key for encryption:"))
+		nk, err := s.askForPrivateKey(color.CyanString("Please select a private key for encryption:"))
 		if err != nil {
 			return err
 		}
@@ -58,7 +57,7 @@ func (s *Action) init(alias, path string, nogit bool, keys ...string) error {
 	fmt.Fprint(color.Output, color.GreenString("Password store %s initialized for:\n", path))
 	for _, recipient := range s.Store.ListRecipients(alias) {
 		r := "0x" + recipient
-		if kl, err := gpg.ListPublicKeys(recipient); err == nil && len(kl) > 0 {
+		if kl, err := s.gpg.FindPublicKeys(recipient); err == nil && len(kl) > 0 {
 			r = kl[0].OneLine()
 		}
 		color.Yellow("  " + r)

--- a/action/recipients.go
+++ b/action/recipients.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/justwatchcom/gopass/gpg"
 	"github.com/urfave/cli"
 )
 
@@ -56,7 +55,7 @@ func (s *Action) RecipientsAdd(c *cli.Context) error {
 	store := c.String("store")
 	added := 0
 	for _, r := range c.Args() {
-		keys, err := gpg.ListPublicKeys(r)
+		keys, err := s.gpg.FindPublicKeys(r)
 		if err != nil {
 			return fmt.Errorf("Failed to list public keys: %s", err)
 		}
@@ -82,7 +81,7 @@ func (s *Action) RecipientsRemove(c *cli.Context) error {
 	store := c.String("store")
 	removed := 0
 	for _, r := range c.Args() {
-		kl, err := gpg.ListPrivateKeys(r)
+		kl, err := s.gpg.FindPrivateKeys(r)
 		if err == nil {
 			if len(kl) > 0 {
 				if !askForConfirmation(fmt.Sprintf("Do you want to remove yourself (%s) from the recipients?", r)) {

--- a/gpg/gpg.go
+++ b/gpg/gpg.go
@@ -4,15 +4,12 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
-	"time"
 )
 
 const (
@@ -20,212 +17,63 @@ const (
 	dirPerm  = 0700
 )
 
-func init() {
-	// ensure created files don't have group or world perms set
-	// this setting should be inherited by sub-processes
-	umask(077)
-}
-
 var (
 	reUIDComment = regexp.MustCompile(`([^(<]+)\s+(\([^)]+\))\s+<([^>]+)>`)
 	reUID        = regexp.MustCompile(`([^(<]+)\s+<([^>]+)>`)
-	// GPGArgs contains the default GPG args for non-interactive use. Note: Do not use '--batch'
+	// defaultArgs contains the default GPG args for non-interactive use. Note: Do not use '--batch'
 	// as this will disable (necessary) passphrase questions!
-	GPGArgs = []string{"--quiet", "--yes", "--compress-algo=none", "--no-encrypt-to", "--no-auto-check-trustdb"}
-	// Debug prints all the commands executed
-	Debug = false
-	// GPGBin is the name and possibly location of the gpg binary
-	GPGBin = "gpg"
+	defaultArgs = []string{"--quiet", "--yes", "--compress-algo=none", "--no-encrypt-to", "--no-auto-check-trustdb"}
 )
 
-func init() {
-	for _, b := range []string{"gpg2", "gpg1", "gpg"} {
+// GPG is a gpg wrapper
+type GPG struct {
+	binary      string
+	args        []string
+	debug       bool
+	pubKeys     KeyList
+	privKeys    KeyList
+	alwaysTrust bool
+}
+
+// Config is the gpg wrapper config
+type Config struct {
+	Binary      string
+	Args        []string
+	Debug       bool
+	AlwaysTrust bool
+}
+
+// New creates a new GPG wrapper
+func New(cfg Config) *GPG {
+	// ensure created files don't have group or world perms set
+	// this setting should be inherited by sub-processes
+	umask(077)
+
+	for _, b := range []string{cfg.Binary, "gpg2", "gpg1", "gpg"} {
 		if p, err := exec.LookPath(b); err == nil {
-			GPGBin = p
+			cfg.Binary = p
 			break
 		}
 	}
-}
-
-// KeyList is a searchable slice of Keys
-type KeyList []Key
-
-// UseableKeys returns the list of useable (valid keys)
-func (kl KeyList) UseableKeys() KeyList {
-	nkl := make(KeyList, 0, len(kl))
-	for _, k := range kl {
-		if !k.IsUseable() {
-			continue
-		}
-		nkl = append(nkl, k)
-	}
-	return nkl
-}
-
-// FindKey will try to find the requested key
-func (kl KeyList) FindKey(id string) (Key, error) {
-	id = strings.TrimPrefix(id, "0x")
-	for _, k := range kl {
-		if k.Fingerprint == id {
-			return k, nil
-		}
-		if strings.HasSuffix(k.Fingerprint, id) {
-			return k, nil
-		}
-		for _, ident := range k.Identities {
-			if ident.String() == id {
-				return k, nil
-			}
-			if ident.Email == id {
-				return k, nil
-			}
-		}
-		for sk := range k.SubKeys {
-			if strings.HasSuffix(sk, id) {
-				return k, nil
-			}
-		}
-	}
-	return Key{}, fmt.Errorf("No matching key found")
-}
-
-// ParseColons parses the `--with-colons` output format of GPG
-func ParseColons(reader io.Reader) KeyList {
-	kl := make(KeyList, 0, 100)
-
-	scanner := bufio.NewScanner(reader)
-
-	// http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
-	// Fields:
-	// 0 - Type of record
-	//     Types:
-	//     pub - Public Key
-	//     crt - X.509 cert
-	//     crs - X.509 cert and private key
-	//     sub - Subkey (Secondary Key)
-	//     sec - Secret / Private Key
-	//     ssb - Secret Subkey
-	//     uid - User ID
-	//     uat - User attribute
-	//     sig - Signature
-	//     rev - Revocation Signature
-	//     fpr - Fingerprint (field 9)
-	//     pkd - Public Key Data
-	//     grp - Keygrip
-	//     rvk - Revocation KEy
-	//     tfs - TOFU stats
-	//     tru - Trust database info
-	//     spk - Signature subpacket
-	//     cfg - Configuration data
-	// 1 - Validity
-	// 2 - Key length
-	// 3 - Public Key Algo
-	// 4 - KeyID
-	// 5 - Creation Date (UTC)
-	// 6 - Expiration Date
-	// 7 - Cert S/N
-	// 8 - Ownertrust
-	// 9 - User-ID
-	// 10 - Sign. Class
-	// 11 - Key Caps.
-	// 12 - Issuer cert fp
-	// 13 - Flag
-	// 14 - S/N of a token
-	// 15 - Hash algo (2 - SHA-1, 8 - SHA-256)
-	// 16 - Curve Name
-
-	var cur Key
-
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		fields := strings.Split(line, ":")
-
-		switch fields[0] {
-		case "pub":
-			fallthrough
-		case "sec":
-			if cur.Fingerprint != "" && cur.KeyLength > 0 {
-				kl = append(kl, cur)
-			}
-			validity := fields[1]
-			if validity == "" && fields[0] == "sec" {
-				validity = "u"
-			}
-			cur = Key{
-				KeyType:        fields[0],
-				Validity:       validity,
-				KeyLength:      parseInt(fields[2]),
-				CreationDate:   parseTS(fields[5]),
-				ExpirationDate: parseTS(fields[6]),
-				Ownertrust:     fields[8],
-				Identities:     make(map[string]Identity, 1),
-				SubKeys:        make(map[string]struct{}, 1),
-			}
-		case "sub":
-			fallthrough
-		case "ssb":
-			cur.SubKeys[fields[4]] = struct{}{}
-		case "fpr":
-			if cur.Fingerprint == "" {
-				cur.Fingerprint = fields[9]
-			}
-		case "uid":
-			sn := fields[7]
-			id := fields[9]
-			ni := Identity{}
-			if reUIDComment.MatchString(id) {
-				if m := reUIDComment.FindStringSubmatch(id); len(m) > 3 {
-					ni.Name = m[1]
-					ni.Comment = strings.Trim(m[2], "()")
-					ni.Email = m[3]
-				}
-			} else if reUID.MatchString(id) {
-				if m := reUID.FindStringSubmatch(id); len(m) > 2 {
-					ni.Name = m[1]
-					ni.Email = m[2]
-				}
-			}
-			cur.Identities[sn] = ni
-		}
+	if len(cfg.Args) < 1 {
+		cfg.Args = defaultArgs
 	}
 
-	if cur.Fingerprint != "" && cur.KeyLength > 0 {
-		kl = append(kl, cur)
+	g := &GPG{
+		binary:      cfg.Binary,
+		args:        cfg.Args,
+		debug:       cfg.Debug,
+		alwaysTrust: cfg.AlwaysTrust,
 	}
-
-	return kl
-}
-
-// parseTS parses the passed string as an Epoch int and returns
-// the time struct or the zero time struct
-func parseTS(str string) time.Time {
-	t := time.Time{}
-
-	if sec, err := strconv.ParseInt(str, 10, 64); err == nil {
-		t = time.Unix(sec, 0)
-	}
-
-	return t
-}
-
-// parseInt parses the passed string as an int and returns it
-// or 0 on errors
-func parseInt(str string) int {
-	i := 0
-
-	if iv, err := strconv.ParseInt(str, 10, 32); err == nil {
-		i = int(iv)
-	}
-
-	return i
+	return g
 }
 
 // listKey lists all keys of the given type and matching the search strings
-func listKeys(typ string, search ...string) (KeyList, error) {
+func (g *GPG) listKeys(typ string, search ...string) (KeyList, error) {
 	args := []string{"--with-colons", "--with-fingerprint", "--fixed-list-mode", "--list-" + typ + "-keys"}
 	args = append(args, search...)
-	cmd := exec.Command(GPGBin, args...)
-	if Debug {
+	cmd := exec.Command(g.binary, args...)
+	if g.debug {
 		fmt.Printf("[DEBUG] gpg.listKeys: %s %+v\n", cmd.Path, cmd.Args)
 	}
 	out, err := cmd.CombinedOutput()
@@ -236,27 +84,53 @@ func listKeys(typ string, search ...string) (KeyList, error) {
 		return KeyList{}, err
 	}
 
-	return ParseColons(bytes.NewBuffer(out)), nil
+	return g.parseColons(bytes.NewBuffer(out)), nil
 }
 
 // ListPublicKeys returns a parsed list of GPG public keys
-func ListPublicKeys(search ...string) (KeyList, error) {
-	return listKeys("public", search...)
+func (g *GPG) ListPublicKeys() (KeyList, error) {
+	if g.pubKeys == nil {
+		kl, err := g.listKeys("public")
+		if err != nil {
+			return nil, err
+		}
+		g.pubKeys = kl
+	}
+	return g.pubKeys, nil
+}
+
+// FindPublicKeys searches for the given public keys
+func (g *GPG) FindPublicKeys(search ...string) (KeyList, error) {
+	// TODO use cache
+	return g.listKeys("public", search...)
 }
 
 // ListPrivateKeys returns a parsed list of GPG secret keys
-func ListPrivateKeys(search ...string) (KeyList, error) {
-	return listKeys("secret", search...)
+func (g *GPG) ListPrivateKeys() (KeyList, error) {
+	if g.privKeys == nil {
+		kl, err := g.listKeys("secret")
+		if err != nil {
+			return nil, err
+		}
+		g.privKeys = kl
+	}
+	return g.privKeys, nil
+}
+
+// FindPrivateKeys searches for the given private keys
+func (g *GPG) FindPrivateKeys(search ...string) (KeyList, error) {
+	// TODO use cache
+	return g.listKeys("secret", search...)
 }
 
 // GetRecipients returns a list of recipient IDs for a given file
-func GetRecipients(file string) ([]string, error) {
+func (g *GPG) GetRecipients(file string) ([]string, error) {
 	_ = os.Setenv("LANGUAGE", "C")
 	recp := make([]string, 0, 5)
 
 	args := []string{"--batch", "--list-only", "--list-packets", "--no-default-keyring", "--secret-keyring", "/dev/null", file}
-	cmd := exec.Command(GPGBin, args...)
-	if Debug {
+	cmd := exec.Command(g.binary, args...)
+	if g.debug {
 		fmt.Printf("[DEBUG] gpg.GetRecipients: %s %+v\n", cmd.Path, cmd.Args)
 	}
 	out, err := cmd.CombinedOutput()
@@ -267,7 +141,7 @@ func GetRecipients(file string) ([]string, error) {
 	scanner := bufio.NewScanner(bytes.NewBuffer(out))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if Debug {
+		if g.debug {
 			fmt.Printf("[DEBUG] gpg Output: %s\n", line)
 		}
 		if !strings.HasPrefix(line, ":pubkey enc packet:") {
@@ -282,29 +156,16 @@ func GetRecipients(file string) ([]string, error) {
 	return recp, nil
 }
 
-func splitPacket(in string) map[string]string {
-	m := make(map[string]string, 3)
-	p := strings.Split(in, ":")
-	if len(p) < 3 {
-		return m
-	}
-	p = strings.Split(strings.TrimSpace(p[2]), " ")
-	for i := 0; i+1 < len(p); i += 2 {
-		m[p[i]] = p[i+1]
-	}
-	return m
-}
-
 // Encrypt will encrypt the given content for the recipients. If alwaysTrust is true
 // the trust-model will be set to always as to avoid (annoying) "unuseable public key"
 // errors when encrypting.
-func Encrypt(path string, content []byte, recipients []string, alwaysTrust bool) error {
+func (g *GPG) Encrypt(path string, content []byte, recipients []string) error {
 	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
 		return err
 	}
 
-	args := append(GPGArgs, "--encrypt", "--output", path)
-	if alwaysTrust {
+	args := append(g.args, "--encrypt", "--output", path)
+	if g.alwaysTrust {
 		// changing the trustmodel is possibly dangerous. A user should always
 		// explicitly opt-in to do this
 		args = append(args, "--trust-model=always")
@@ -313,8 +174,8 @@ func Encrypt(path string, content []byte, recipients []string, alwaysTrust bool)
 		args = append(args, "--recipient", r)
 	}
 
-	cmd := exec.Command(GPGBin, args...)
-	if Debug {
+	cmd := exec.Command(g.binary, args...)
+	if g.debug {
 		fmt.Printf("[DEBUG] gpg.Encrypt: %s %+v\n", cmd.Path, cmd.Args)
 	}
 	cmd.Stdin = bytes.NewReader(content)
@@ -325,20 +186,20 @@ func Encrypt(path string, content []byte, recipients []string, alwaysTrust bool)
 }
 
 // Decrypt will try to decrypt the given file
-func Decrypt(path string) ([]byte, error) {
-	args := append(GPGArgs, "--decrypt", path)
-	cmd := exec.Command(GPGBin, args...)
-	if Debug {
+func (g *GPG) Decrypt(path string) ([]byte, error) {
+	args := append(g.args, "--decrypt", path)
+	cmd := exec.Command(g.binary, args...)
+	if g.debug {
 		fmt.Printf("[DEBUG] gpg.Decrypt: %s %+v\n", cmd.Path, cmd.Args)
 	}
 	return cmd.Output()
 }
 
 // ExportPublicKey will export the named public key to the location given
-func ExportPublicKey(id, filename string) error {
-	args := append(GPGArgs, "--armor", "--export", id)
-	cmd := exec.Command(GPGBin, args...)
-	if Debug {
+func (g *GPG) ExportPublicKey(id, filename string) error {
+	args := append(g.args, "--armor", "--export", id)
+	cmd := exec.Command(g.binary, args...)
+	if g.debug {
 		fmt.Printf("[DEBUG] gpg.ExportPublicKey: %s %+v\n", cmd.Path, cmd.Args)
 	}
 	out, err := cmd.Output()
@@ -350,20 +211,26 @@ func ExportPublicKey(id, filename string) error {
 }
 
 // ImportPublicKey will import a key from the given location
-func ImportPublicKey(filename string) error {
+func (g *GPG) ImportPublicKey(filename string) error {
 	buf, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return err
 	}
 
-	args := append(GPGArgs, "--import")
-	cmd := exec.Command(GPGBin, args...)
-	if Debug {
+	args := append(g.args, "--import")
+	cmd := exec.Command(g.binary, args...)
+	if g.debug {
 		fmt.Printf("[DEBUG] gpg.ImportPublicKey: %s %+v\n", cmd.Path, cmd.Args)
 	}
 	cmd.Stdin = bytes.NewReader(buf)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	return cmd.Run()
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	// clear key cache
+	g.privKeys = nil
+	g.pubKeys = nil
+	return nil
 }

--- a/gpg/key.go
+++ b/gpg/key.go
@@ -2,6 +2,7 @@ package gpg
 
 import (
 	"fmt"
+	"sort"
 	"time"
 )
 
@@ -55,9 +56,14 @@ func (k Key) String() string {
 // OneLine prints a terse representation of this key on one line (includes only
 // the first identity!)
 func (k Key) OneLine() string {
+	ids := make([]string, 0, len(k.Identities))
+	for i := range k.Identities {
+		ids = append(ids, i)
+	}
+	sort.Strings(ids)
 	id := Identity{}
-	for _, i := range k.Identities {
-		id = i
+	for _, i := range ids {
+		id = k.Identities[i]
 		break
 	}
 	return fmt.Sprintf("0x%s - %s", k.Fingerprint[24:], id.ID())

--- a/gpg/key_list.go
+++ b/gpg/key_list.go
@@ -1,0 +1,48 @@
+package gpg
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KeyList is a searchable slice of Keys
+type KeyList []Key
+
+// UseableKeys returns the list of useable (valid keys)
+func (kl KeyList) UseableKeys() KeyList {
+	nkl := make(KeyList, 0, len(kl))
+	for _, k := range kl {
+		if !k.IsUseable() {
+			continue
+		}
+		nkl = append(nkl, k)
+	}
+	return nkl
+}
+
+// FindKey will try to find the requested key
+func (kl KeyList) FindKey(id string) (Key, error) {
+	id = strings.TrimPrefix(id, "0x")
+	for _, k := range kl {
+		if k.Fingerprint == id {
+			return k, nil
+		}
+		if strings.HasSuffix(k.Fingerprint, id) {
+			return k, nil
+		}
+		for _, ident := range k.Identities {
+			if ident.String() == id {
+				return k, nil
+			}
+			if ident.Email == id {
+				return k, nil
+			}
+		}
+		for sk := range k.SubKeys {
+			if strings.HasSuffix(sk, id) {
+				return k, nil
+			}
+		}
+	}
+	return Key{}, fmt.Errorf("No matching key found")
+}

--- a/gpg/parse_colons.go
+++ b/gpg/parse_colons.go
@@ -1,0 +1,114 @@
+package gpg
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// http://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=blob_plain;f=doc/DETAILS
+// Fields:
+// 0 - Type of record
+//     Types:
+//     pub - Public Key
+//     crt - X.509 cert
+//     crs - X.509 cert and private key
+//     sub - Subkey (Secondary Key)
+//     sec - Secret / Private Key
+//     ssb - Secret Subkey
+//     uid - User ID
+//     uat - User attribute
+//     sig - Signature
+//     rev - Revocation Signature
+//     fpr - Fingerprint (field 9)
+//     pkd - Public Key Data
+//     grp - Keygrip
+//     rvk - Revocation KEy
+//     tfs - TOFU stats
+//     tru - Trust database info
+//     spk - Signature subpacket
+//     cfg - Configuration data
+// 1 - Validity
+// 2 - Key length
+// 3 - Public Key Algo
+// 4 - KeyID
+// 5 - Creation Date (UTC)
+// 6 - Expiration Date
+// 7 - Cert S/N
+// 8 - Ownertrust
+// 9 - User-ID
+// 10 - Sign. Class
+// 11 - Key Caps.
+// 12 - Issuer cert fp
+// 13 - Flag
+// 14 - S/N of a token
+// 15 - Hash algo (2 - SHA-1, 8 - SHA-256)
+// 16 - Curve Name
+
+// parseColons parses the `--with-colons` output format of GPG
+func (g *GPG) parseColons(reader io.Reader) KeyList {
+	kl := make(KeyList, 0, 100)
+
+	scanner := bufio.NewScanner(reader)
+
+	var cur Key
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		fields := strings.Split(line, ":")
+
+		switch fields[0] {
+		case "pub":
+			fallthrough
+		case "sec":
+			if cur.Fingerprint != "" && cur.KeyLength > 0 {
+				kl = append(kl, cur)
+			}
+			validity := fields[1]
+			if validity == "" && fields[0] == "sec" {
+				validity = "u"
+			}
+			cur = Key{
+				KeyType:        fields[0],
+				Validity:       validity,
+				KeyLength:      parseInt(fields[2]),
+				CreationDate:   parseTS(fields[5]),
+				ExpirationDate: parseTS(fields[6]),
+				Ownertrust:     fields[8],
+				Identities:     make(map[string]Identity, 1),
+				SubKeys:        make(map[string]struct{}, 1),
+			}
+		case "sub":
+			fallthrough
+		case "ssb":
+			cur.SubKeys[fields[4]] = struct{}{}
+		case "fpr":
+			if cur.Fingerprint == "" {
+				cur.Fingerprint = fields[9]
+			}
+		case "uid":
+			sn := fields[7]
+			id := fields[9]
+			ni := Identity{}
+			if reUIDComment.MatchString(id) {
+				if m := reUIDComment.FindStringSubmatch(id); len(m) > 3 {
+					ni.Name = m[1]
+					ni.Comment = strings.Trim(m[2], "()")
+					ni.Email = m[3]
+				}
+			} else if reUID.MatchString(id) {
+				if m := reUID.FindStringSubmatch(id); len(m) > 2 {
+					ni.Name = m[1]
+					ni.Email = m[2]
+				}
+			}
+			cur.Identities[sn] = ni
+		}
+	}
+
+	if cur.Fingerprint != "" && cur.KeyLength > 0 {
+		kl = append(kl, cur)
+	}
+
+	return kl
+}

--- a/gpg/utils.go
+++ b/gpg/utils.go
@@ -1,0 +1,44 @@
+package gpg
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parseTS parses the passed string as an Epoch int and returns
+// the time struct or the zero time struct
+func parseTS(str string) time.Time {
+	t := time.Time{}
+
+	if sec, err := strconv.ParseInt(str, 10, 64); err == nil {
+		t = time.Unix(sec, 0)
+	}
+
+	return t
+}
+
+// parseInt parses the passed string as an int and returns it
+// or 0 on errors
+func parseInt(str string) int {
+	i := 0
+
+	if iv, err := strconv.ParseInt(str, 10, 32); err == nil {
+		i = int(iv)
+	}
+
+	return i
+}
+
+func splitPacket(in string) map[string]string {
+	m := make(map[string]string, 3)
+	p := strings.Split(in, ":")
+	if len(p) < 3 {
+		return m
+	}
+	p = strings.Split(strings.TrimSpace(p[2]), " ")
+	for i := 0; i+1 < len(p); i += 2 {
+		m[p[i]] = p[i+1]
+	}
+	return m
+}

--- a/store/root/recipients.go
+++ b/store/root/recipients.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/justwatchcom/gopass/gpg"
 	"github.com/justwatchcom/gopass/tree"
 	"github.com/justwatchcom/gopass/tree/simple"
 )
@@ -37,9 +36,9 @@ func (r *Store) RecipientsTree(pretty bool) (tree.Tree, error) {
 		if err := root.AddMount(alias, substore.Path()); err != nil {
 			return nil, fmt.Errorf("failed to add mount: %s", err)
 		}
-		for _, r := range substore.Recipients() {
-			key := fmt.Sprintf("%s (missing public key)", r)
-			kl, err := gpg.ListPublicKeys(r)
+		for _, recp := range substore.Recipients() {
+			key := fmt.Sprintf("%s (missing public key)", recp)
+			kl, err := r.gpg.FindPublicKeys(recp)
 			if err == nil {
 				if len(kl) > 0 {
 					if pretty {
@@ -55,8 +54,8 @@ func (r *Store) RecipientsTree(pretty bool) (tree.Tree, error) {
 		}
 	}
 
-	for _, r := range r.store.Recipients() {
-		kl, err := gpg.ListPublicKeys(r)
+	for _, recp := range r.store.Recipients() {
+		kl, err := r.gpg.FindPublicKeys(recp)
 		if err != nil {
 			fmt.Println(err)
 			continue

--- a/store/root/store.go
+++ b/store/root/store.go
@@ -2,12 +2,12 @@ package root
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
 	"github.com/justwatchcom/gopass/config"
 	"github.com/justwatchcom/gopass/fsutil"
+	"github.com/justwatchcom/gopass/gpg"
 	"github.com/justwatchcom/gopass/store"
 	"github.com/justwatchcom/gopass/store/sub"
 	"github.com/justwatchcom/gopass/tree"
@@ -24,6 +24,7 @@ type Store struct {
 	clipTimeout int  // clear clipboard after seconds
 	debug       bool
 	fsckFunc    store.FsckCallback
+	gpg         *gpg.GPG
 	importFunc  store.ImportCallback
 	loadKeys    bool // load missing keys from store
 	mounts      map[string]*sub.Store
@@ -53,6 +54,10 @@ func New(cfg *config.Config) (*Store, error) {
 		clipTimeout: cfg.ClipTimeout,
 		debug:       cfg.Debug,
 		fsckFunc:    cfg.FsckFunc,
+		gpg: gpg.New(gpg.Config{
+			Debug:       cfg.Debug,
+			AlwaysTrust: cfg.AlwaysTrust,
+		}),
 		importFunc:  cfg.ImportFunc,
 		loadKeys:    cfg.LoadKeys,
 		mounts:      make(map[string]*sub.Store, len(cfg.Mounts)),
@@ -61,11 +66,6 @@ func New(cfg *config.Config) (*Store, error) {
 		path:        cfg.Path,
 		persistKeys: cfg.PersistKeys,
 		safeContent: cfg.SafeContent,
-	}
-
-	// TODO(dschulz) this should be passed down from main, not set here
-	if d := os.Getenv("GOPASS_DEBUG"); d == "true" {
-		r.debug = true
 	}
 
 	if r.autoImport {

--- a/store/sub/fsck.go
+++ b/store/sub/fsck.go
@@ -14,7 +14,7 @@ import (
 
 // Fsck checks this stores integrity
 func (s *Store) Fsck(prefix string, check, force bool) (map[string]uint64, error) {
-	storeRec, err := gpg.ListPublicKeys(s.recipients...)
+	storeRec, err := s.gpg.FindPublicKeys(s.recipients...)
 	if err != nil {
 		fmt.Printf("Failed to list recipients: %s\n", err)
 	}
@@ -144,7 +144,7 @@ func (s *Store) fsckCheckFile(prefix, fn string, check, force bool, storeRec gpg
 		return nil
 	}
 	// get the IDs this file was encrypted for
-	fileRec, err := gpg.GetRecipients(fn)
+	fileRec, err := s.gpg.GetRecipients(fn)
 	if err != nil {
 		fmt.Println(color.RedString("[%s] Failed to check recipients: %s (%s)", prefix, fn, err))
 		countFn("err")

--- a/store/sub/recipients.go
+++ b/store/sub/recipients.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/fsutil"
-	"github.com/justwatchcom/gopass/gpg"
 	"github.com/justwatchcom/gopass/store"
 )
 
@@ -49,7 +48,7 @@ func (s *Store) AddRecipient(id string) error {
 func (s *Store) RemoveRecipient(id string) error {
 	// but if this key is not available on this machine we
 	// just try to remove it literally
-	keys, err := gpg.ListPublicKeys(id)
+	keys, err := s.gpg.FindPublicKeys(id)
 	if err != nil {
 		fmt.Printf("Failed to get GPG Key Info for %s: %s\n", id, err)
 	}
@@ -101,7 +100,7 @@ func (s *Store) loadRecipients() ([]string, error) {
 		// we could list all keys outside the loop and just do the lookup here
 		// but this way we ensure to use the exact same lookup logic as
 		// gpg does on encryption
-		kl, err := gpg.ListPublicKeys(r)
+		kl, err := s.gpg.FindPublicKeys(r)
 		if err != nil {
 			fmt.Printf("Failed to get public key for %s: %s\n", r, err)
 			continue
@@ -266,7 +265,7 @@ func (s *Store) exportPublicKey(r string) (string, error) {
 		return filename, nil
 	}
 
-	if err := gpg.ExportPublicKey(r, filename); err != nil {
+	if err := s.gpg.ExportPublicKey(r, filename); err != nil {
 		return filename, err
 	}
 
@@ -280,5 +279,5 @@ func (s *Store) importPublicKey(r string) error {
 		return fmt.Errorf("Public Key %s not found at %s", r, filename)
 	}
 
-	return gpg.ImportPublicKey(filename)
+	return s.gpg.ImportPublicKey(filename)
 }


### PR DESCRIPTION
This PR refactors the GPG package. Right now it shouldn't have any noticeable effect, but in the future this should enable caching of slow "get keys" operations as well as adding a venue to (partly) replacing GPG by `golang.org/x/crypto/openpgp` (or similar).