### PR TITLE
Don't wrap dmenu anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,23 +389,18 @@ autocompletion for subcommands like `gopass show`, `gopass ls` and others.
     source <(gopass completion bash)
     source <(gopass completion zsh)
 
-### dmenu support
+### dmenu/rofi support
 
-Out of the box gopass supports [dmenu](http://tools.suckless.org/dmenu/).
-Instead of shipping another bash script we ship dmenu support from within the binary.
+In earlier versions gopass supported [dmenu](http://tools.suckless.org/dmenu/).
+We removed this and encourage you to call dmenu yourself now.
 
-If you have dmenu installed on your system simply run:
-
-```bash
-$ gopass completion dmenu
-```
-The first line of your selected secret will be copied to your clipboard.
-
-Maybe you want the password to be written to your selected text field.
-For that add `--type` and make sure _xdotool_ is installed.
+This also makes it easier to call gopass with e.g. [rofi](https://github.com/DaveDavenport/rofi).
 
 ```bash
-$ gopass completion dmenu --type
+# Simply copy the selected password to the clipboard
+$ gopass ls --flat | dmenu | xargs --no-run-if-empty gopass show -c
+# First pipe the selected name to gopass, encrypt it and type the password with xdotool.
+$ gopass ls --flat | dmenu | xargs --no-run-if-empty gopass show | xdotool type --clearmodifiers --file -
 ```
 
 ### Dependencies

--- a/action/completion.go
+++ b/action/completion.go
@@ -1,13 +1,8 @@
 package action
 
 import (
-	"bytes"
 	"fmt"
-	"os"
-	"os/exec"
-	"strings"
 
-	shellquote "github.com/kballard/go-shellquote"
 	"github.com/urfave/cli"
 )
 
@@ -55,55 +50,4 @@ source <(gopass completion bash)
 	fmt.Println(out)
 
 	return nil
-}
-
-// CompletionDMenu returns a script that starts dmenu
-// Usage: eval "$(gopass completion dmenu)"
-func (s *Action) CompletionDMenu(c *cli.Context) error {
-	typeit := c.Bool("type")
-	args := c.String("args")
-
-	list, err := s.Store.List(0)
-	if err != nil {
-		return err
-	}
-
-	argsSplit, err := shellquote.Split(args)
-	if err != nil {
-		return err
-	}
-
-	name, err := dmenu(list, argsSplit...)
-	if err != nil {
-		return err
-	}
-
-	content, err := s.Store.GetFirstLine(name)
-	if err != nil {
-		return err
-	}
-
-	if typeit {
-		return exec.Command("xdotool", "type", "--clearmodifiers", "--", string(content)).Run()
-	}
-
-	return s.copyToClipboard(name, content)
-}
-
-// dmenu runs it with the provided strings and returns the selected string
-func dmenu(list []string, args ...string) (string, error) {
-	stdin := bytes.NewBuffer(nil)
-	for _, v := range list {
-		_, _ = stdin.WriteString(v + "\n")
-	}
-
-	cmd := exec.Command("dmenu", args...)
-	cmd.Stdin = stdin
-	cmd.Stderr = os.Stderr
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-
-	return strings.TrimSpace(string(out)), nil
 }

--- a/main.go
+++ b/main.go
@@ -164,20 +164,6 @@ func main() {
 				Name:   "zsh",
 				Usage:  "Source for auto completion in zsh",
 				Action: action.CompletionZSH,
-			}, {
-				Name:   "dmenu",
-				Usage:  "Completion output for dmenu",
-				Action: action.CompletionDMenu,
-				Flags: []cli.Flag{
-					cli.BoolFlag{
-						Name:  "type",
-						Usage: "Type the password with xdotool",
-					},
-					cli.StringFlag{
-						Name:  "args",
-						Usage: "Arguments passed to dmenu itself",
-					},
-				},
 			}},
 		},
 		{


### PR DESCRIPTION
Update the README on how to use dmenu now.
Using some pipes we can get rid of wrapping everything.

Replacing `dmenu` with `rofi` in these pipes should do the trick now.

Closes #73
Closes #76
