### PR TITLE
Avoid running pager if not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ $ gopass cp emails/example.com emails/user@example.com
 
 ## Advanced Features
 
+### Auto-Pager
+
+Like other popular open-source projects `gopass` automatically pipe the output
+to `$PAGER` if it's longer than one terminal page. You can disable this behaviour
+by unsetting `$PAGER` or `gopass config nopager true`.
+
 ### git auto-push and auto-pull
 
 If you want gopass to always push changes in git to your default remote (origin)

--- a/action/list.go
+++ b/action/list.go
@@ -37,7 +37,7 @@ func (s *Action) List(c *cli.Context) error {
 			}
 			return nil
 		}
-		if rows, _ := termutil.GetTermsize(); l.Len() > rows {
+		if rows, _ := termutil.GetTermsize(); l.Len() > rows && !s.Store.NoPager() {
 			color.NoColor = true
 			buf = &bytes.Buffer{}
 			out = buf
@@ -85,7 +85,8 @@ func (s *Action) List(c *cli.Context) error {
 func (s *Action) pager(buf io.Reader) error {
 	pager := os.Getenv("PAGER")
 	if pager == "" {
-		pager = "pager"
+		fmt.Println(buf)
+		return nil
 	}
 
 	args, err := shellquote.Split(pager)

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Mounts      map[string]string    `json:"mounts,omitempty"`
 	NoColor     bool                 `json:"nocolor"`     // disable colors in output
 	NoConfirm   bool                 `json:"noconfirm"`   // do not confirm recipients when encrypting
+	NoPager     bool                 `json:"nopager"`     // do not start a pager for longer output
 	Path        string               `json:"path"`        // path to the root store
 	PersistKeys bool                 `json:"persistkeys"` // store recipient keys in store
 	SafeContent bool                 `json:"safecontent"` // avoid showing passwords in terminal
@@ -49,6 +50,7 @@ func New() *Config {
 		Mounts:      make(map[string]string),
 		NoColor:     false,
 		NoConfirm:   false,
+		NoPager:     false,
 		PersistKeys: true,
 		SafeContent: false,
 		Version:     "",

--- a/store/root/config.go
+++ b/store/root/config.go
@@ -20,6 +20,7 @@ func (s *Store) Config() *config.Config {
 		Mounts:      make(map[string]string, len(s.mounts)),
 		NoColor:     s.noColor,
 		NoConfirm:   s.noConfirm,
+		NoPager:     s.noPager,
 		Path:        s.path,
 		PersistKeys: s.persistKeys,
 		SafeContent: s.safeContent,
@@ -47,6 +48,7 @@ func (s *Store) UpdateConfig(cfg *config.Config) error {
 	s.loadKeys = cfg.LoadKeys
 	s.noColor = cfg.NoColor
 	s.noConfirm = cfg.NoConfirm
+	s.noPager = cfg.NoPager
 	s.path = cfg.Path
 	s.persistKeys = cfg.PersistKeys
 	s.safeContent = cfg.SafeContent
@@ -116,4 +118,9 @@ func (s *Store) ClipTimeout() int {
 // AskForMore returns true if generate should ask for more information
 func (s *Store) AskForMore() bool {
 	return s.askForMore
+}
+
+// NoPager retuns true if the user doesn't want a pager for longer output
+func (s *Store) NoPager() bool {
+	return s.noPager
 }

--- a/store/root/store.go
+++ b/store/root/store.go
@@ -28,8 +28,9 @@ type Store struct {
 	importFunc  store.ImportCallback
 	loadKeys    bool // load missing keys from store
 	mounts      map[string]*sub.Store
-	noColor     bool   // disable colors in output
-	noConfirm   bool   // do not confirm recipients when encrypting
+	noColor     bool // disable colors in output
+	noConfirm   bool // do not confirm recipients when encrypting
+	noPager     bool
 	path        string // path to the root store
 	persistKeys bool   // store recipient keys in store
 	safeContent bool   // avoid showing passwords in terminal
@@ -63,6 +64,7 @@ func New(cfg *config.Config) (*Store, error) {
 		mounts:      make(map[string]*sub.Store, len(cfg.Mounts)),
 		noColor:     cfg.NoColor,
 		noConfirm:   cfg.NoConfirm,
+		noPager:     cfg.NoPager,
 		path:        cfg.Path,
 		persistKeys: cfg.PersistKeys,
 		safeContent: cfg.SafeContent,


### PR DESCRIPTION
This PR avoids starting a pager if $PAGER is not set or the, newly introduced,
config option nopager is true.

Fixes #167