### PR TITLE
Modify generate to only change the first line

### DIFF
--- a/action/generate.go
+++ b/action/generate.go
@@ -40,7 +40,7 @@ func (s *Action) Generate(c *cli.Context) error {
 	}
 
 	if !force { // don't check if it's force anyway
-		if s.Store.Exists(name) && key == "" && !s.askForConfirmation(fmt.Sprintf("An entry already exists for %s. Overwrite it?", name)) {
+		if s.Store.Exists(name) && key == "" && !s.askForConfirmation(fmt.Sprintf("An entry already exists for %s. Overwrite the current password?", name)) {
 			return fmt.Errorf("not overwriting your current password")
 		}
 	}
@@ -65,6 +65,10 @@ func (s *Action) Generate(c *cli.Context) error {
 	// set a single key in a yaml doc
 	if key != "" {
 		if err := s.Store.SetKey(name, key, string(password)); err != nil {
+			return err
+		}
+	} else if s.Store.Exists(name) {
+		if err := s.Store.SetPassword(name, password); err != nil {
 			return err
 		}
 	} else {

--- a/store/root/store.go
+++ b/store/root/store.go
@@ -237,6 +237,12 @@ func (r *Store) Set(name string, content []byte, reason string) error {
 	return store.Set(strings.TrimPrefix(name, store.Alias()), content, reason)
 }
 
+// SetPassword Update only the first line in an already existing entry
+func (r *Store) SetPassword(name string, password []byte) error {
+	store := r.getStore(name)
+	return store.SetPassword(strings.TrimPrefix(name, store.Alias()), password)
+}
+
 // SetConfirm calls Set with confirmation callback
 func (r *Store) SetConfirm(name string, content []byte, reason string, cb store.RecipientCallback) error {
 	store := r.getStore(name)

--- a/store/sub/store.go
+++ b/store/sub/store.go
@@ -251,6 +251,17 @@ func (s *Store) Set(name string, content []byte, reason string) error {
 	return s.SetConfirm(name, content, reason, nil)
 }
 
+// SetPassword update a password in an already existing entry on the disk
+func (s *Store) SetPassword(name string, password []byte) error {
+	var err error
+	body, err := s.GetBody(name)
+	if err != nil && err != store.ErrNoBody {
+		return err
+	}
+	first := append(password, '\n')
+	return s.SetConfirm(name, append(first, body...), fmt.Sprintf("Updated password in %s", name), nil)
+}
+
 // SetConfirm encodes and writes the cipertext of one entry to disk. This
 // method can be passed a callback to confirm the recipients immedeately
 // before encryption.


### PR DESCRIPTION
When a user runs generate on an already existing entry - it will completely override the whole entry.
With this change, it will only update the first line. 

Related to #172.