### PR TITLE
Completion respects escaping

### DIFF
--- a/action/completion.go
+++ b/action/completion.go
@@ -2,9 +2,22 @@ package action
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/urfave/cli"
 )
+
+var escapeRegExp = regexp.MustCompile(`(\s|\(|\)|\<|\>|\&|\;|\#|\\|\||\*|\?)`)
+
+// bashEscape Escape special characters with `\`
+func bashEscape(s string) string {
+	return escapeRegExp.ReplaceAllStringFunc(s, func(c string) string {
+		if c == `\` {
+			return `\\\\`
+		}
+		return `\\` + c
+	})
+}
 
 // Complete prints a list of all password names to os.Stdout
 func (s *Action) Complete(*cli.Context) {
@@ -14,7 +27,7 @@ func (s *Action) Complete(*cli.Context) {
 	}
 
 	for _, v := range list {
-		fmt.Println(v)
+		fmt.Println(bashEscape(v))
 	}
 }
 
@@ -27,6 +40,7 @@ PROG=gopass
 _cli_bash_autocomplete() {
      local cur opts base
      COMPREPLY=()
+     local IFS=$'\n'
      cur="${COMP_WORDS[COMP_CWORD]}"
      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )

--- a/action/completion_test.go
+++ b/action/completion_test.go
@@ -1,0 +1,10 @@
+package action
+
+import "testing"
+
+func TestBashEscape(t *testing.T) {
+	expected := `a\\<\\>\\|\\\\and\\ sometimes\\?\\*\\(\\)\\&\\;\\#`
+	if escaped := bashEscape(`a<>|\and sometimes?*()&;#`); escaped != expected {
+		t.Errorf("Expected %q, but got %q", expected, escaped)
+	}
+}

--- a/tests/completion_test.go
+++ b/tests/completion_test.go
@@ -22,6 +22,7 @@ PROG=gopass
 _cli_bash_autocomplete() {
      local cur opts base
      COMPREPLY=()
+     local IFS=$'\n'
      cur="${COMP_WORDS[COMP_CWORD]}"
      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )


### PR DESCRIPTION
Related to #99.
Cause `compgen` is actually pretty bad in handling spaces, escaping part was implemented in `go`.
