### PR TITLE
Check for already existing entries, when add mount

### DIFF
--- a/action/mount.go
+++ b/action/mount.go
@@ -63,7 +63,11 @@ func (s *Action) MountAdd(c *cli.Context) error {
 	if k := c.String("init"); k != "" {
 		keys = append(keys, k)
 	}
-	if err := s.Store.AddMount(c.Args()[0], c.Args()[1], keys...); err != nil {
+	alias, localPath := c.Args()[0], c.Args()[1]
+	if s.Store.Exists(alias) {
+		fmt.Printf(color.YellowString("WARNING: shadowing %s entry\n"), alias)
+	}
+	if err := s.Store.AddMount(alias, localPath, keys...); err != nil {
 		return err
 	}
 	if err := s.Store.Config().Save(); err != nil {


### PR DESCRIPTION
When a user adds a new mount there is a possibility, that entry with this name already exist.
Example:
```
gopass generate test 24
gopass mount add test ~/.test-password-store
```
After that one could not reveal `test.gpg` in the root store, until mount test is unmount.