### PR TITLE
README: correct .deb download URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,8 +363,8 @@ $ brew install gopass
 #### Debian and Ubuntu
 
 ```bash
-$ wget https://www.justwatch.com/gopass/releases/1.2.0/gopass_1.2.0_amd64.deb
-$ sudo dpkg -i gopass_1.2.0_amd64.deb
+$ wget https://www.justwatch.com/gopass/releases/1.2.0/gopass-1.2.0-linux-amd64.deb
+$ sudo dpkg -i gopass-1.2.0-linux-amd64.deb
 ```
 
 ### Download


### PR DESCRIPTION
Hi, I came across a 404 while following along with the README. You could perhaps generally use a _/latest_ or _/stable_ URL so you don't have to change docs for version bumps?