### PR TITLE
configure user.name, user.email before initial git commit (#179)

### DIFF
--- a/action/clihelper.go
+++ b/action/clihelper.go
@@ -197,8 +197,8 @@ func (s *Action) askForPrivateKey(prompt string) (string, error) {
 // git config user.name and git config user.email, respectively.
 func (s *Action) askForGitConfigUser() (string, string, error) {
 	var (
-		name string = ""
-		email string = ""
+		name string
+		email string
 	)
 
 	if !s.isTerm {

--- a/action/clihelper.go
+++ b/action/clihelper.go
@@ -216,16 +216,17 @@ func (s *Action) askForGitConfigUser() (string, string, error) {
 
 			if !s.isTerm {
 				return identity.Name, identity.Email, nil
-			} else {
-				useCurrent, err = s.askForBool(
-					fmt.Sprintf("Use %s (%s) for password store git config?", identity.Name, identity.Email), false)
-				if err != nil {
-					return "", "", err
-				}
-				if useCurrent {
-					return identity.Name, identity.Email, nil
-				}
 			}
+
+			useCurrent, err = s.askForBool(
+				fmt.Sprintf("Use %s (%s) for password store git config?", identity.Name, identity.Email), false)
+			if err != nil {
+				return "", "", err
+			}
+			if useCurrent {
+				return identity.Name, identity.Email, nil
+			}
+
 		}
 	}
 

--- a/action/clihelper.go
+++ b/action/clihelper.go
@@ -213,9 +213,6 @@ func (s *Action) askForGitConfigUser() (string, string, error) {
 		return "", "", fmt.Errorf("No usable private keys found")
 	}
 
-	if err != nil {
-		return "", "", err
-	}
 	for _, key := range keyList {
 		for _, identity := range key.Identities {
 			ok, err := s.askForBool(fmt.Sprintf("Use %q as user name for password store git config?", identity.Name), false)

--- a/action/clihelper_test.go
+++ b/action/clihelper_test.go
@@ -1,0 +1,42 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_askForGitConfigUser(t *testing.T) {
+	s := New("test-init")
+	s.isTerm = true
+
+	_, _, err := s.askForGitConfigUser()
+	if err == nil {
+		t.Error("Did not return error")
+	}
+}
+
+func Test_askForGitConfigUserNonInteractive(t *testing.T) {
+	s := New("test-init")
+	// for explicitness
+	s.isTerm = false
+
+	keyList, err := s.gpg.ListPrivateKeys()
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	name, email, err := s.askForGitConfigUser()
+	assert.NoError(t, err)
+
+	// tests cannot know whether keyList returned empty or not.
+	// a better distinction would require mocking/patching
+	// calls to s.gpg.ListPrivateKeys()
+	if len(keyList) > 0 {
+		assert.NotEqual(t, "", name)
+		assert.NotEqual(t, "", email)
+	} else {
+		assert.Equal(t, "", name)
+		assert.Equal(t, "", email)
+	}
+}

--- a/action/clihelper_test.go
+++ b/action/clihelper_test.go
@@ -28,7 +28,7 @@ func Test_askForGitConfigUserNonInteractive(t *testing.T) {
 
 	name, email, _ := s.askForGitConfigUser()
 
-	// tests cannot know whether keyList returned empty or not.
+	// unit tests cannot know whether keyList returned empty or not.
 	// a better distinction would require mocking/patching
 	// calls to s.gpg.ListPrivateKeys()
 	if len(keyList) > 0 {

--- a/action/clihelper_test.go
+++ b/action/clihelper_test.go
@@ -26,8 +26,7 @@ func Test_askForGitConfigUserNonInteractive(t *testing.T) {
 		t.Error(err.Error())
 	}
 
-	name, email, err := s.askForGitConfigUser()
-	assert.NoError(t, err)
+	name, email, _ := s.askForGitConfigUser()
 
 	// tests cannot know whether keyList returned empty or not.
 	// a better distinction would require mocking/patching

--- a/action/git.go
+++ b/action/git.go
@@ -13,7 +13,7 @@ func (s *Action) Git(c *cli.Context) error {
 	return s.Store.Git(store, c.Args()...)
 }
 
-// GitInit initializes a git repo
+// GitInit initializes a git repo including basic configuration
 func (s *Action) GitInit(c *cli.Context) error {
 	store := c.String("store")
 	sk := c.String("sign-key")
@@ -29,7 +29,19 @@ func (s *Action) gitInit(store, sk string) error {
 		}
 	}
 
-	if err := s.Store.GitInit(store, sk); err != nil {
+	// for convenience, set defaults to user-selected values from available private keys
+	userName, userEmail, err := s.askForGitConfigUser()
+
+	userName, err = s.askForString(color.CyanString("Please enter a user name for password store git config"), userName)
+	if err != nil {
+		return err
+	}
+	userEmail, err = s.askForString(color.CyanString("Please enter an email address for password store git config"), userEmail)
+	if err != nil {
+		return err
+	}
+
+	if err := s.Store.GitInit(store, sk, userName, userEmail); err != nil {
 		return err
 	}
 	fmt.Fprintln(color.Output, color.GreenString("Git initialized"))

--- a/action/git.go
+++ b/action/git.go
@@ -30,9 +30,10 @@ func (s *Action) gitInit(store, sk string) error {
 	}
 
 	// for convenience, set defaults to user-selected values from available private keys
-	userName, userEmail, err := s.askForGitConfigUser()
+	// NB: discarding returned error since this is merely a best-effort look-up for convenience
+	userName, userEmail, _ := s.askForGitConfigUser()
 
-	userName, err = s.askForString(color.CyanString("Please enter a user name for password store git config"), userName)
+	userName, err := s.askForString(color.CyanString("Please enter a user name for password store git config"), userName)
 	if err != nil {
 		return err
 	}

--- a/store/root/git.go
+++ b/store/root/git.go
@@ -1,9 +1,9 @@
 package root
 
 // GitInit initializes the git repo
-func (r *Store) GitInit(name, sk string) error {
+func (r *Store) GitInit(name, sk, userName, userEmail string) error {
 	store := r.getStore(name)
-	return store.GitInit(store.Alias(), sk)
+	return store.GitInit(store.Alias(), sk, userName, userEmail)
 }
 
 // Git runs arbitrary git commands on this store and all substores

--- a/store/sub/git.go
+++ b/store/sub/git.go
@@ -28,13 +28,20 @@ func (s *Store) gitCmd(name string, args ...string) error {
 
 // GitInit initializes this store's git repo and
 // recursively calls GitInit on all substores.
-func (s *Store) GitInit(alias, signKey string) error {
+func (s *Store) GitInit(alias, signKey, userName, userEmail string) error {
 	// the git repo may be empty (i.e. no branches, cloned from a fresh remote)
 	// or already initialized. Only run git init if the folder is completely empty
 	if !s.isGit() {
 		if err := s.gitCmd("GitInit", "init"); err != nil {
 			return fmt.Errorf("Failed to initialize git: %s", err)
 		}
+	}
+
+	if err := s.gitCmd("GitInit", "config", "--local", "user.name", userName); err != nil {
+		return err
+	}
+	if err := s.gitCmd("GitInit", "config", "--local", "user.email", userEmail); err != nil {
+		return err
 	}
 
 	if err := s.gitAdd(s.path); err != nil {

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -1,0 +1,23 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInit(t *testing.T) {
+	ts := newTester(t)
+	defer ts.teardown()
+
+	out, err := ts.run("init")
+	assert.Error(t, err)
+	assert.Equal(t, "\nError: no interaction without terminal\n", out)
+
+	ts = newTester(t)
+	defer ts.teardown()
+
+	out, err = ts.run("init " + keyID)
+	assert.NoError(t, err)
+	assert.Contains(t, out, "Please enter a user name for password store git config [John Doe]:")
+}


### PR DESCRIPTION
Avoid potential failure on initial git commit:
Prompt user for necessary git config values and
provide private key identity names/emails
as suggestions for convenience.