### PR TITLE
Add YAML document marker

### DIFF
--- a/gpg/mock/gpg.go
+++ b/gpg/mock/gpg.go
@@ -1,0 +1,65 @@
+package mock
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/justwatchcom/gopass/gpg"
+)
+
+// Mocker is a no-op GPG mock
+type Mocker struct{}
+
+// New creates a new GPG mock
+func New() *Mocker {
+	return &Mocker{}
+}
+
+// ListPublicKeys does nothing
+func (m *Mocker) ListPublicKeys() (gpg.KeyList, error) {
+	return gpg.KeyList{}, nil
+}
+
+// FindPublicKeys does nothing
+func (m *Mocker) FindPublicKeys(...string) (gpg.KeyList, error) {
+	return gpg.KeyList{}, nil
+}
+
+// ListPrivateKeys does nothing
+func (m *Mocker) ListPrivateKeys() (gpg.KeyList, error) {
+	return gpg.KeyList{}, nil
+}
+
+// FindPrivateKeys does nothing
+func (m *Mocker) FindPrivateKeys(...string) (gpg.KeyList, error) {
+	return gpg.KeyList{}, nil
+}
+
+// GetRecipients does nothing
+func (m *Mocker) GetRecipients(string) ([]string, error) {
+	return []string{}, nil
+}
+
+// Encrypt writes the input to disk unaltered
+func (m *Mocker) Encrypt(path string, content []byte, recipients []string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, content, 0600)
+}
+
+// Decrypt read the file from disk unaltered
+func (m *Mocker) Decrypt(path string) ([]byte, error) {
+	return ioutil.ReadFile(path)
+}
+
+// ExportPublicKey does nothing
+func (m *Mocker) ExportPublicKey(string, string) error {
+	return nil
+}
+
+// ImportPublicKey does nothing
+func (m *Mocker) ImportPublicKey(string) error {
+	return nil
+}

--- a/gpg/mock/gpg.go
+++ b/gpg/mock/gpg.go
@@ -63,3 +63,8 @@ func (m *Mocker) ExportPublicKey(string, string) error {
 func (m *Mocker) ImportPublicKey(string) error {
 	return nil
 }
+
+// Version returns dummy version info
+func (m *Mocker) Version() gpg.Version {
+	return gpg.Version{}
+}

--- a/store/err.go
+++ b/store/err.go
@@ -25,4 +25,8 @@ var (
 	ErrNoBody = fmt.Errorf("no safe content to display, you can force display with show -f")
 	// ErrNoPassword is returned is a secret exists but has no password, only a body
 	ErrNoPassword = fmt.Errorf("no password to display")
+	// ErrYAMLNoMark is returned if a secret contains no valid YAML document marker
+	ErrYAMLNoMark = fmt.Errorf("no YAML document marker found")
+	// ErrYAMLNoKey is returned if a YAML document doesn't contain a key
+	ErrYAMLNoKey = fmt.Errorf("key not found in YAML document")
 )

--- a/store/sub/recipients_test.go
+++ b/store/sub/recipients_test.go
@@ -22,7 +22,7 @@ func TestLoadRecipients(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
-	genRecs, _, err := createStore(tempdir)
+	genRecs, _, err := createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
 
 	s, err := New("", &config.Config{Path: tempdir})
@@ -41,7 +41,7 @@ func TestSaveRecipients(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
-	genRecs, _, err := createStore(tempdir)
+	genRecs, _, err := createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
 
 	s, err := New("", &config.Config{Path: tempdir})
@@ -84,7 +84,7 @@ func TestAddRecipient(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
-	genRecs, _, err := createStore(tempdir)
+	genRecs, _, err := createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
 
 	s, err := New("", &config.Config{Path: tempdir})
@@ -112,7 +112,7 @@ func TestRemoveRecipient(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
-	genRecs, _, err := createStore(tempdir)
+	genRecs, _, err := createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
 
 	s, err := New("", &config.Config{Path: tempdir})
@@ -135,7 +135,7 @@ func TestListRecipients(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(tempdir)
 	}()
-	genRecs, _, err := createStore(tempdir)
+	genRecs, _, err := createStore(tempdir, nil, nil)
 	assert.NoError(t, err)
 
 	s, err := New("", &config.Config{Path: tempdir})

--- a/store/sub/store.go
+++ b/store/sub/store.go
@@ -19,6 +19,18 @@ const (
 	GPGID = ".gpg-id"
 )
 
+type gpger interface {
+	ListPublicKeys() (gpg.KeyList, error)
+	FindPublicKeys(...string) (gpg.KeyList, error)
+	ListPrivateKeys() (gpg.KeyList, error)
+	FindPrivateKeys(...string) (gpg.KeyList, error)
+	GetRecipients(string) ([]string, error)
+	Encrypt(string, []byte, []string) error
+	Decrypt(string) ([]byte, error)
+	ExportPublicKey(string, string) error
+	ImportPublicKey(string) error
+}
+
 // Store is password store
 type Store struct {
 	alias           string
@@ -34,7 +46,7 @@ type Store struct {
 	path            string
 	persistKeys     bool
 	recipients      []string
-	gpg             *gpg.GPG
+	gpg             gpger
 }
 
 // New creates a new store, copying settings from the given root store

--- a/store/sub/store.go
+++ b/store/sub/store.go
@@ -29,6 +29,7 @@ type gpger interface {
 	Decrypt(string) ([]byte, error)
 	ExportPublicKey(string, string) error
 	ImportPublicKey(string) error
+	Version() gpg.Version
 }
 
 // Store is password store

--- a/store/sub/store_test.go
+++ b/store/sub/store_test.go
@@ -8,25 +8,29 @@ import (
 	"strings"
 )
 
-func createStore(dir string) ([]string, []string, error) {
-	recipients := []string{
-		"0xDEADBEEF",
-		"0xFEEDBEEF",
+func createStore(dir string, recipients, entries []string) ([]string, []string, error) {
+	if recipients == nil {
+		recipients = []string{
+			"0xDEADBEEF",
+			"0xFEEDBEEF",
+		}
 	}
-	list := []string{
-		"foo/bar/baz",
-		"baz/ing/a",
+	if entries == nil {
+		entries = []string{
+			"foo/bar/baz",
+			"baz/ing/a",
+		}
 	}
-	sort.Strings(list)
-	for _, file := range list {
+	sort.Strings(entries)
+	for _, file := range entries {
 		filename := filepath.Join(dir, file+".gpg")
 		if err := os.MkdirAll(filepath.Dir(filename), 0700); err != nil {
-			return recipients, list, err
+			return recipients, entries, err
 		}
 		if err := ioutil.WriteFile(filename, []byte{}, 0644); err != nil {
-			return recipients, list, err
+			return recipients, entries, err
 		}
 	}
 	err := ioutil.WriteFile(filepath.Join(dir, GPGID), []byte(strings.Join(recipients, "\n")), 0600)
-	return recipients, list, err
+	return recipients, entries, err
 }

--- a/store/sub/yaml_test.go
+++ b/store/sub/yaml_test.go
@@ -1,0 +1,185 @@
+package sub
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	gpgmock "github.com/justwatchcom/gopass/gpg/mock"
+	"github.com/justwatchcom/gopass/store"
+)
+
+const (
+	yamlSecret   = "foo"
+	yamlKey      = "bar"
+	yamlValue    = "baz"
+	yamlPassword = "zzz"
+)
+
+/*
+- empty doc (get/set)
+- only pw (get/set)
+- no pw (get/set)
+- pw and yaml (get/set)
+- no sep / sep (get/set)
+*/
+func TestYAML(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tf   func(s *Store) func(t *testing.T)
+	}{
+		{
+			name: "Get Key from empty Secret",
+			tf: func(s *Store) func(t *testing.T) {
+				return func(t *testing.T) {
+					_, err := s.GetKey(yamlSecret, yamlKey)
+					if err == nil {
+						t.Errorf("Should complain about missing YAML marker")
+					}
+				}
+			},
+		},
+		{
+			name: "Set Key to empty Secret",
+			tf: func(s *Store) func(t *testing.T) {
+				return func(t *testing.T) {
+					// write key
+					err := s.SetKey(yamlSecret, yamlKey, yamlValue)
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					// read back key
+					content, err := s.GetKey(yamlSecret, yamlKey)
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					if string(content) != yamlValue {
+						t.Errorf("Wrong value: %s", content)
+					}
+					// read back whole entry
+					content, err = s.Get(yamlSecret)
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					want := "\n---\n" + yamlKey + ": " + yamlValue + "\n"
+					if string(content) != want {
+						t.Errorf("Wrong value: '%s' != '%s'", content, want)
+					}
+				}
+			},
+		},
+		{
+			name: "Get key from password-only secret",
+			tf: func(s *Store) func(t *testing.T) {
+				return func(t *testing.T) {
+					// write password
+					err := s.Set(yamlSecret, []byte(yamlPassword), "testing")
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					// read (non-existing) key
+					_, err = s.GetKey(yamlSecret, yamlKey)
+					if err == nil {
+						t.Errorf("Should complain about missing YAML marker")
+					}
+					// read back whole entry
+					content, err := s.Get(yamlSecret)
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					want := string(yamlPassword)
+					if string(content) != want {
+						t.Errorf("Wrong value: '%s' != '%s'", content, want)
+					}
+				}
+			},
+		},
+		{
+			name: "Set key to password-only secret",
+			tf: func(s *Store) func(t *testing.T) {
+				return func(t *testing.T) {
+					// write password
+					err := s.Set(yamlSecret, []byte(yamlPassword), "testing")
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					// set new key
+					err = s.SetKey(yamlSecret, yamlKey, yamlValue)
+					if err != nil {
+						t.Fatalf("Failed to write new key: %s", err)
+					}
+					// read back the password
+					pw, err := s.GetFirstLine(yamlSecret)
+					if err != nil {
+						t.Fatalf("Failed to read password: %s", err)
+					}
+					if string(pw) != yamlPassword {
+						t.Errorf("Wrong password: %s", pw)
+					}
+					// read back the key
+					content, err := s.GetKey(yamlSecret, yamlKey)
+					if err != nil {
+						t.Fatalf("Failed to read key %s: %s", yamlKey, err)
+					}
+					if string(content) != yamlValue {
+						t.Errorf("Wrong value: %s", content)
+					}
+					// read back whole entry
+					content, err = s.Get(yamlSecret)
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					want := yamlPassword + "\n---\nbar: baz\n"
+					if string(content) != want {
+						t.Errorf("Wrong value: '%s' != '%s'", content, want)
+					}
+				}
+			},
+		},
+		{
+			name: "Bare YAML - no document marker - read key",
+			tf: func(s *Store) func(t *testing.T) {
+				return func(t *testing.T) {
+					secret := "bar: baz\nzab: 123\n"
+					// write password
+					err := s.Set(yamlSecret, []byte(secret), "testing")
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					// read back a key
+					_, err = s.GetKey(yamlSecret, yamlKey)
+					if err != store.ErrYAMLNoMark {
+						t.Fatalf("Should fail to read YAML without document marker")
+					}
+					// read back whole entry
+					content, err := s.Get(yamlSecret)
+					if err != nil {
+						t.Fatalf("%s", err)
+					}
+					if string(content) != secret {
+						t.Errorf("Wrong value: '%s' != '%s'", content, secret)
+					}
+				}
+			},
+		},
+	} {
+		// common setup
+		tempdir, err := ioutil.TempDir("", "gopass-")
+		if err != nil {
+			t.Fatalf("Failed to create tempdir: %s", err)
+		}
+
+		s := &Store{
+			alias:      "",
+			path:       tempdir,
+			gpg:        gpgmock.New(),
+			recipients: []string{"john.doe"},
+		}
+
+		// run test case
+		t.Run(tc.name, tc.tf(s))
+
+		// common tear down
+		_ = os.RemoveAll(tempdir)
+	}
+}

--- a/tests/yaml_test.go
+++ b/tests/yaml_test.go
@@ -17,7 +17,7 @@ func TestYAMLAndSecret(t *testing.T) {
 
 	out, err := ts.run("foo/bar baz")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Entry is not in the password store\n", out)
+	assert.Equal(t, "\nError: no YAML document marker found\n", out)
 
 	_, err = ts.runCmd([]string{ts.Binary, "insert", "foo/bar"}, []byte("moar"))
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR changes an important heuristic: It is no longer legal to have an YAML document without an introductory `document marker` (an optional start marker in the YAML spec).

On the one hand this makes YAML handling more robust and deterministic, but on the other hand this makes it a little less convenient.

Please help me decide if we want to enforce them or not. I'd like to get this PR merged in any case, but we could decide to **not enforce** the markers (i.e. support docs with and without markers and just add them on any change).

Fixes #192