### PR TITLE
add hint for adding secondary stores (#98)

### DIFF
--- a/store/sub/store.go
+++ b/store/sub/store.go
@@ -83,7 +83,7 @@ func (s *Store) Initialized() bool {
 func (s *Store) Init(path string, ids ...string) error {
 	if s.Initialized() {
 		return fmt.Errorf(`Found already initialized store at %s.
-You can add secondary stores with gopass init --store <path to secondary store> --alias <mount name>.`, path)
+You can add secondary stores with gopass init --store <path to secondary store> --alias <mount name>`, path)
 	}
 
 	// initialize recipient list

--- a/store/sub/store.go
+++ b/store/sub/store.go
@@ -82,7 +82,8 @@ func (s *Store) Initialized() bool {
 // Init tries to initalize a new password store location matching the object
 func (s *Store) Init(path string, ids ...string) error {
 	if s.Initialized() {
-		return fmt.Errorf("Store is already initialized")
+		return fmt.Errorf(`Found already initialized store at %s.
+You can add secondary stores with gopass init --store <path to secondary store> --alias <mount name>.`, path)
 	}
 
 	// initialize recipient list

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -20,4 +20,18 @@ func TestInit(t *testing.T) {
 	out, err = ts.run("init " + keyID)
 	assert.NoError(t, err)
 	assert.Contains(t, out, "Please enter a user name for password store git config [John Doe]:")
+	
+	ts = newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+	// try to init again
+	out, err = ts.run("init "  + keyID)
+	assert.Error(t, err)
+	for _, o := range []string{
+		"Error: Found already initialized store at /tmp/gopass-",
+		"You can add secondary stores with gopass init --store <path to secondary store> --alias <mount name>.",
+	} {
+		assert.Contains(t, out, o)
+	}
 }

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -30,7 +30,7 @@ func TestInit(t *testing.T) {
 	assert.Error(t, err)
 	for _, o := range []string{
 		"Error: Found already initialized store at /tmp/gopass-",
-		"You can add secondary stores with gopass init --store <path to secondary store> --alias <mount name>.",
+		"You can add secondary stores with gopass init --store <path to secondary store> --alias <mount name>",
 	} {
 		assert.Contains(t, out, o)
 	}


### PR DESCRIPTION
...in case an already initialized primary store is found

Does this cover use case 2 (#98)?