### PR TITLE
Also Import missing keys on recipients show

### DIFF
--- a/action/recipients.go
+++ b/action/recipients.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 
@@ -28,6 +29,9 @@ credentials.
 
 // RecipientsPrint prints all recipients per store
 func (s *Action) RecipientsPrint(c *cli.Context) error {
+	if err := s.Store.ImportMissingPublicKeys(); err != nil {
+		fmt.Println(color.RedString("Failed to import missing public keys: %s", err))
+	}
 	tree, err := s.Store.RecipientsTree(true)
 	if err != nil {
 		return err

--- a/store/root/recipients.go
+++ b/store/root/recipients.go
@@ -40,6 +40,21 @@ func (r *Store) addRecipient(prefix string, root tree.Tree, recp string, pretty 
 	return root.AddFile(prefix+key, "gopass/recipient")
 }
 
+// ImportMissingPublicKeys import missing public keys in any substore
+func (r *Store) ImportMissingPublicKeys() error {
+	if !r.loadKeys {
+		return nil
+	}
+
+	for alias, sub := range r.mounts {
+		if err := sub.ImportMissingPublicKeys(); err != nil {
+			fmt.Println(color.RedString("[%s] Failed to import missing public keys: %s", alias, err))
+		}
+	}
+
+	return r.store.ImportMissingPublicKeys()
+}
+
 // RecipientsTree returns a tree view of all stores' recipients
 func (r *Store) RecipientsTree(pretty bool) (tree.Tree, error) {
 	root := simple.New("gopass")

--- a/store/sub/git.go
+++ b/store/sub/git.go
@@ -34,7 +34,7 @@ func (s *Store) gitCmd(name string, args ...string) error {
 		if s.debug {
 			fmt.Printf("[DEBUG] importing possilby missing keys ...\n")
 		}
-		if err := s.importMissingPublicKeys(); err != nil {
+		if err := s.ImportMissingPublicKeys(); err != nil {
 			return err
 		}
 	}

--- a/store/sub/recipients.go
+++ b/store/sub/recipients.go
@@ -92,7 +92,7 @@ func (s *Store) loadRecipients() ([]string, error) {
 	return unmarshalRecipients(f), nil
 }
 
-func (s *Store) importMissingPublicKeys() error {
+func (s *Store) ImportMissingPublicKeys() error {
 	for _, r := range s.recipients {
 		if s.debug {
 			fmt.Printf("[DEBUG] Checking recipients %s ...\n", r)

--- a/store/sub/recipients.go
+++ b/store/sub/recipients.go
@@ -92,6 +92,8 @@ func (s *Store) loadRecipients() ([]string, error) {
 	return unmarshalRecipients(f), nil
 }
 
+// ImportMissingPublicKeys will try to import any missing public keys from the
+// .gpg-keys folder in the password store
 func (s *Store) ImportMissingPublicKeys() error {
 	for _, r := range s.recipients {
 		if s.debug {


### PR DESCRIPTION
This PR also calls the import missing key func when requesting a recipient listing - an operation that takes some time anyway. This was we can try to ensure that no missing recipients keys are show in the recipients output.