### PR TITLE
Add version check

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -14,10 +14,11 @@ import (
 
 // Action knows everything to run gopass CLI actions
 type Action struct {
-	Name   string
-	Store  *root.Store
-	gpg    *gpg.GPG
-	isTerm bool
+	Name    string
+	Store   *root.Store
+	gpg     *gpg.GPG
+	isTerm  bool
+	version string
 }
 
 // New returns a new Action wrapper
@@ -32,8 +33,9 @@ func New(v string) *Action {
 	cfg.Version = v
 
 	act := &Action{
-		Name:   name,
-		isTerm: true,
+		Name:    name,
+		version: v,
+		isTerm:  true,
 	}
 	cfg.ImportFunc = act.askForKeyImport
 	cfg.FsckFunc = act.askForConfirmation

--- a/action/version.go
+++ b/action/version.go
@@ -29,7 +29,7 @@ func (s *Action) Version(c *cli.Context) error {
 	}
 
 	if r.Name != s.version {
-		fmt.Println(color.YellowString("\nYour version of gopass is out of date!\nThe latest version is %s.\nYou can update by downloading from www.justwatch.com/gopass", r.Name))
+		fmt.Println(color.YellowString("\nYour version of gopass is out of date!\nThe latest version is %s.\nYou can update by downloading from www.justwatch.com/gopass or via your package manager", r.Name))
 	}
 
 	return nil

--- a/action/version.go
+++ b/action/version.go
@@ -2,7 +2,10 @@ package action
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/dominikschulz/github-releases/ghrel"
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 
@@ -14,6 +17,20 @@ func (s *Action) Version(c *cli.Context) error {
 	fmt.Printf("  GPG: %d.%d.%d\n", gv.Major, gv.Minor, gv.Patch)
 	gmaj, gmin, gpa := s.Store.GitVersion()
 	fmt.Printf("  Git: %d.%d.%d\n", gmaj, gmin, gpa)
+
+	if disabled := os.Getenv("CHECKPOINT_DISABLE"); disabled != "" {
+		return nil
+	}
+
+	r, err := ghrel.FetchLatestStableRelease("justwatchcom", "gopass")
+	if err != nil {
+		fmt.Println(color.RedString("\nError checking latest version: %s", err))
+		os.Exit(1)
+	}
+
+	if r.Name != s.version {
+		fmt.Println(color.YellowString("\nYour version of gopass is out of date!\nThe latest version is %s.\nYou can update by downloading from www.justwatch.com/gopass", r.Name))
+	}
 
 	return nil
 }

--- a/vendor/github.com/dominikschulz/github-releases/ghrel/releases.go
+++ b/vendor/github.com/dominikschulz/github-releases/ghrel/releases.go
@@ -1,0 +1,52 @@
+package ghrel
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var apiURL = "https://api.github.com/repos/%s/%s/releases"
+
+type Asset struct {
+	Id   int    `json:"id"`
+	Name string `json:"name"`
+	URL  string `json:"browser_download_url"`
+}
+
+type Release struct {
+	Id          int       `json:"id"`
+	Name        string    `json:"name"`
+	PublishedAt time.Time `json:"published_at"`
+	Assets      []Asset   `json:"assets"`
+}
+
+func FetchLatestStableRelease(user, project string) (Release, error) {
+	url := fmt.Sprintf(apiURL, user, project)
+	resp, err := http.Get(url)
+	if err != nil {
+		return Release{}, fmt.Errorf("Failed to fetch from %s: %s", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return Release{}, fmt.Errorf("Failed to fetch from %s: %d - %s", url, resp.StatusCode, resp.Status)
+	}
+	var rs []Release
+	err = json.NewDecoder(resp.Body).Decode(&rs)
+	if err != nil {
+		return Release{}, err
+	}
+	if len(rs) < 1 {
+		return Release{}, fmt.Errorf("No releases")
+	}
+	for _, r := range rs {
+		if strings.Contains(r.Name, "beta") || strings.Contains(r.Name, "rc") {
+			continue
+		}
+		return r, nil
+	}
+	return Release{}, fmt.Errorf("No stable release found")
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -40,6 +40,12 @@
 			"revisionTime": "2016-09-25T22:06:09Z"
 		},
 		{
+			"checksumSHA1": "3RHnsFotgXOZhHTPP8yQLaMvnlA=",
+			"path": "github.com/dominikschulz/github-releases/ghrel",
+			"revision": "73e103dfac4c5e2df2a448c9ca4ae295e7595e5b",
+			"revisionTime": "2017-07-20T13:41:49Z"
+		},
+		{
 			"checksumSHA1": "x77xUarDfVxctJMAJPCQzlYk8JM=",
 			"path": "github.com/fatih/color",
 			"revision": "bf82308e8c8546dc2b945157173eb8a959ae9505",


### PR DESCRIPTION
This PR adds a version check to the `gopass version` subcommand.
It will make an unauthenticated call to the GitHub REST API v3 every time the user runs `gopass version` unless `CHECKPOINT_DISABLE` is non-empty.