### PR TITLE
Save recipients on show

### DIFF
--- a/action/recipients.go
+++ b/action/recipients.go
@@ -32,6 +32,9 @@ func (s *Action) RecipientsPrint(c *cli.Context) error {
 	if err := s.Store.ImportMissingPublicKeys(); err != nil {
 		fmt.Println(color.RedString("Failed to import missing public keys: %s", err))
 	}
+	if err := s.Store.SaveRecipients(); err != nil {
+		fmt.Println(color.RedString("Failed to export missing public keys: %s", err))
+	}
 	tree, err := s.Store.RecipientsTree(true)
 	if err != nil {
 		return err

--- a/gpg/gpg.go
+++ b/gpg/gpg.go
@@ -208,6 +208,10 @@ func (g *GPG) ExportPublicKey(id, filename string) error {
 		return err
 	}
 
+	if len(out) < 1 {
+		return fmt.Errorf("Key not found")
+	}
+
 	return ioutil.WriteFile(filename, out, fileMode)
 }
 

--- a/store/err.go
+++ b/store/err.go
@@ -19,6 +19,8 @@ var (
 	ErrGitNotInit = fmt.Errorf("git is not initialized")
 	// ErrGitNoRemote is returned if git has no origin remote
 	ErrGitNoRemote = fmt.Errorf("git has no remote origin")
+	// ErrGitNothingToCommit is returned if there are no staged changes
+	ErrGitNothingToCommit = fmt.Errorf("git has nothing to commit")
 	// ErrNoBody is returned if a secret exists but has no content beyond a password
 	ErrNoBody = fmt.Errorf("no safe content to display, you can force display with show -f")
 	// ErrNoPassword is returned is a secret exists but has no password, only a body

--- a/store/root/recipients.go
+++ b/store/root/recipients.go
@@ -55,6 +55,22 @@ func (r *Store) ImportMissingPublicKeys() error {
 	return r.store.ImportMissingPublicKeys()
 }
 
+// SaveRecipients persists the recipients to disk. Only useful if persist keys is
+// enabled
+func (r *Store) SaveRecipients() error {
+	if !r.persistKeys {
+		return nil
+	}
+
+	for alias, sub := range r.mounts {
+		if err := sub.SaveRecipients(); err != nil {
+			fmt.Println(color.RedString("[%s] Failed to save recipients: %s", alias, err))
+		}
+	}
+
+	return r.store.SaveRecipients()
+}
+
 // RecipientsTree returns a tree view of all stores' recipients
 func (r *Store) RecipientsTree(pretty bool) (tree.Tree, error) {
 	root := simple.New("gopass")

--- a/store/sub/git.go
+++ b/store/sub/git.go
@@ -132,10 +132,22 @@ func (s *Store) gitAdd(files ...string) error {
 	return s.gitCmd("gitAdd", args...)
 }
 
+// gitStagedChanges returns true if there are any staged changes which can be commited
+func (s *Store) gitStagedChanges() bool {
+	if err := s.gitCmd("gitDiffIndex", "diff-index", "--quiet", "HEAD"); err != nil {
+		return true
+	}
+	return false
+}
+
 // gitCommit creates a new git commit with the given commit message
 func (s *Store) gitCommit(msg string) error {
 	if !s.isGit() {
 		return store.ErrGitNotInit
+	}
+
+	if !s.gitStagedChanges() {
+		return store.ErrGitNothingToCommit
 	}
 
 	return s.gitCmd("gitCommit", "commit", "-m", msg)

--- a/store/sub/recipients.go
+++ b/store/sub/recipients.go
@@ -44,6 +44,11 @@ func (s *Store) AddRecipient(id string) error {
 	return s.reencrypt("Added Recipient " + id)
 }
 
+// SaveRecipients persists the current recipients on disk
+func (s *Store) SaveRecipients() error {
+	return s.saveRecipients("Save Recipients")
+}
+
 // RemoveRecipient will remove the given recipient from the storefunc (s *Store) RemoveRecipient()id string) error {
 func (s *Store) RemoveRecipient(id string) error {
 	// but if this key is not available on this machine we
@@ -145,7 +150,7 @@ func (s *Store) saveRecipients(msg string) error {
 	err := s.gitAdd(s.idFile())
 	if err == nil {
 		if err := s.gitCommit(msg); err != nil {
-			if err != store.ErrGitNotInit {
+			if err != store.ErrGitNotInit && err != store.ErrGitNothingToCommit {
 				return err
 			}
 		}
@@ -191,7 +196,7 @@ func (s *Store) saveRecipients(msg string) error {
 			}
 			return err
 		}
-		if err := s.gitCommit(fmt.Sprintf("Exported Public Keys %s", r)); err != nil {
+		if err := s.gitCommit(fmt.Sprintf("Exported Public Keys %s", r)); err != nil && err != store.ErrGitNothingToCommit {
 			fmt.Println(color.RedString("Failed to git commit: %s", err))
 			continue
 		}


### PR DESCRIPTION
Recipients are usually saved when adding or removing one.
In case the user changes the value of "persistkeys" this is not persisted unless a recipient is added or removed.

This PR changes the `recipients show` command to not only load missing recipients keys from the store (already implemented in #204) but also save any keys localy available but maybe missing in the stores .gpg-keys dir.

In order to do this I had to improve error handling wrt. git which will also be useful in other places/usecases.