### PR TITLE
Include GPG and Git Version in gopass version

### DIFF
--- a/action/version.go
+++ b/action/version.go
@@ -1,9 +1,19 @@
 package action
 
-import "github.com/urfave/cli"
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
 
 // Version prints the gopass version
 func (s *Action) Version(c *cli.Context) error {
 	cli.VersionPrinter(c)
+
+	gv := s.Store.GPGVersion()
+	fmt.Printf("  GPG: %d.%d.%d\n", gv.Major, gv.Minor, gv.Patch)
+	gmaj, gmin, gpa := s.Store.GitVersion()
+	fmt.Printf("  Git: %d.%d.%d\n", gmaj, gmin, gpa)
+
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -48,15 +48,26 @@ func main() {
 		if version == "" {
 			version = "HEAD"
 		}
-		if commit == "" {
-			commit = "n/a"
+		buildInfo := ""
+		if commit != "" {
+			buildInfo = commit
 		}
-		fmt.Printf("%s %s (%s %s) %s\n",
+		if buildtime != "" {
+			if buildInfo != "" {
+				buildInfo += " "
+			}
+			buildInfo += buildtime
+		}
+		if buildInfo != "" {
+			buildInfo = "(" + buildInfo + ") "
+		}
+		fmt.Printf("%s %s %s%s %s %s\n",
 			name,
 			version,
-			commit,
-			buildtime,
+			buildInfo,
 			runtime.Version(),
+			runtime.GOOS,
+			runtime.GOARCH,
 		)
 	}
 

--- a/store/root/git.go
+++ b/store/root/git.go
@@ -13,6 +13,11 @@ func (r *Store) GitInit(name, sk, userName, userEmail string) error {
 	return store.GitInit(store.Alias(), sk, userName, userEmail)
 }
 
+// GitVersion returns git version information
+func (r *Store) GitVersion() (int, int, int) {
+	return r.store.GitVersion()
+}
+
 // Git runs arbitrary git commands on this store and all substores
 func (r *Store) Git(name string, recurse, force bool, args ...string) error {
 	store := r.getStore(name)

--- a/store/root/gpg.go
+++ b/store/root/gpg.go
@@ -1,0 +1,8 @@
+package root
+
+import "github.com/justwatchcom/gopass/gpg"
+
+// GPGVersion returns GPG version information
+func (r *Store) GPGVersion() gpg.Version {
+	return r.store.GPGVersion()
+}

--- a/store/sub/git.go
+++ b/store/sub/git.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/fatih/color"
@@ -103,6 +104,33 @@ func (s *Store) gitSetSignKey(sk string) error {
 	}
 
 	return s.gitCmd("gitSetSignKey", "config", "--local", "commit.gpgsign", "true")
+}
+
+// GitVersion returns the git version as major, minor and patch level
+func (s *Store) GitVersion() (int, int, int) {
+	cmd := exec.Command("git", "version")
+	cmd.Dir = s.path
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, 0, 0
+	}
+	p := strings.Split(strings.TrimPrefix(string(out), "git version "), ".")
+	if len(p) < 3 {
+		return 0, 0, 0
+	}
+	major := 0
+	minor := 0
+	patch := 0
+	if iv, err := strconv.Atoi(p[0]); err == nil {
+		major = iv
+	}
+	if iv, err := strconv.Atoi(p[1]); err == nil {
+		minor = iv
+	}
+	if iv, err := strconv.Atoi(p[2]); err == nil {
+		patch = iv
+	}
+	return major, minor, patch
 }
 
 // Git runs arbitrary git commands on this store

--- a/store/sub/gpg.go
+++ b/store/sub/gpg.go
@@ -1,0 +1,8 @@
+package sub
+
+import "github.com/justwatchcom/gopass/gpg"
+
+// GPGVersion returns parsed GPG version information
+func (s *Store) GPGVersion() gpg.Version {
+	return s.gpg.Version()
+}


### PR DESCRIPTION
To help users collecting all relevant information for bug reports, I'd like to include Git and GPG version information in the output of `gopass version` as well.