### PR TITLE
Unmarshal YAML into map[string]interface{}

### DIFF
--- a/action/show.go
+++ b/action/show.go
@@ -40,6 +40,9 @@ func (s *Action) Show(c *cli.Context) error {
 	case key != "":
 		content, err = s.Store.GetKey(name, key)
 		if err != nil {
+			if err == store.ErrYAMLKeyUnsupported {
+				return fmt.Errorf("Can not show nested key directly. Use 'gopass show %s'", name)
+			}
 			return err
 		}
 		if clip {

--- a/action/show.go
+++ b/action/show.go
@@ -40,7 +40,7 @@ func (s *Action) Show(c *cli.Context) error {
 	case key != "":
 		content, err = s.Store.GetKey(name, key)
 		if err != nil {
-			if err == store.ErrYAMLKeyUnsupported {
+			if err == store.ErrYAMLValueUnsupported {
 				return fmt.Errorf("Can not show nested key directly. Use 'gopass show %s'", name)
 			}
 			return err

--- a/store/err.go
+++ b/store/err.go
@@ -29,6 +29,6 @@ var (
 	ErrYAMLNoMark = fmt.Errorf("no YAML document marker found")
 	// ErrYAMLNoKey is returned if a YAML document doesn't contain a key
 	ErrYAMLNoKey = fmt.Errorf("key not found in YAML document")
-	// ErrYAMLKeyUnsupported is returned is the user tries to unmarshal an nested struct
-	ErrYAMLKeyUnsupported = fmt.Errorf("can not unmarshal nested YAML key")
+	// ErrYAMLValueUnsupported is returned is the user tries to unmarshal an nested struct
+	ErrYAMLValueUnsupported = fmt.Errorf("can not unmarshal nested YAML value")
 )

--- a/store/err.go
+++ b/store/err.go
@@ -29,4 +29,6 @@ var (
 	ErrYAMLNoMark = fmt.Errorf("no YAML document marker found")
 	// ErrYAMLNoKey is returned if a YAML document doesn't contain a key
 	ErrYAMLNoKey = fmt.Errorf("key not found in YAML document")
+	// ErrYAMLKeyUnsupported is returned is the user tries to unmarshal an nested struct
+	ErrYAMLKeyUnsupported = fmt.Errorf("can not unmarshal nested YAML key")
 )

--- a/store/sub/yaml.go
+++ b/store/sub/yaml.go
@@ -20,13 +20,16 @@ func (s *Store) GetKey(name, key string) ([]byte, error) {
 		return nil, store.ErrYAMLNoMark
 	}
 
-	d := make(map[string]string)
+	d := make(map[string]interface{})
 	if err := yaml.Unmarshal(parts[1], &d); err != nil {
 		return nil, err
 	}
 
 	if v, found := d[key]; found {
-		return []byte(v), nil
+		if sv, ok := v.(string); ok {
+			return []byte(sv), nil
+		}
+		return nil, store.ErrYAMLKeyUnsupported
 	}
 
 	return nil, store.ErrYAMLNoKey
@@ -41,7 +44,7 @@ func (s *Store) SetKey(name, key, value string) error {
 
 	parts := bytes.Split(content, []byte("---\n"))
 
-	d := make(map[string]string)
+	d := make(map[string]interface{})
 	if len(parts) > 1 {
 		if err := yaml.Unmarshal(parts[1], &d); err != nil {
 			return err
@@ -67,7 +70,7 @@ func (s *Store) DeleteKey(name, key string) error {
 
 	parts := bytes.Split(content, []byte("---\n"))
 
-	d := make(map[string]string)
+	d := make(map[string]interface{})
 	if len(parts) > 1 {
 		if err := yaml.Unmarshal(parts[1], &d); err != nil {
 			return err

--- a/store/sub/yaml.go
+++ b/store/sub/yaml.go
@@ -29,7 +29,7 @@ func (s *Store) GetKey(name, key string) ([]byte, error) {
 		if sv, ok := v.(string); ok {
 			return []byte(sv), nil
 		}
-		return nil, store.ErrYAMLKeyUnsupported
+		return nil, store.ErrYAMLValueUnsupported
 	}
 
 	return nil, store.ErrYAMLNoKey


### PR DESCRIPTION
This improves handling of nested YAML documentens and makes error messages
more meaningful.

Fixes #196