### PR TITLE
Added `gopass check` command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: required
 before_install:
   - go get -v github.com/golang/lint/golint
   - sudo apt-get update -qq
-  - sudo apt-get install -y libcrack2
+  - sudo apt-get install -y libcrack2-dev
 
 after_success:
   - gem install fpm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@ language: go
 go:
   - 1.8.x
 
+sudo: required
 before_install:
   - go get -v github.com/golang/lint/golint
+  - sudo apt-get update -qq
+  - sudo apt-get install -y libcrack2
 
 after_success:
   - gem install fpm

--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ We also support `pull before push` to reduce the change of `rejected` pushes whe
 $ gopass config autopull true
 ```
 
+### Check Passwords for Common Flaws
+
+gopass can check your passwords for common flaws, like being too short or coming
+from a dictionary.
+
+```bash
+$ gopass check
+Weak password for golang.org/gopher: it is too short
+```
+
 ### Support for Binary Content
 
 gopass provides secure and easy support for working with binary files through the
@@ -426,17 +436,18 @@ $ gopass ls --flat | dmenu | xargs --no-run-if-empty gopass show | xdotool type 
 
 * `gpg`
 * `git`
+* `cracklib`
 
 On Debian-based Linux systems you should run this command:
 
 ```bash
-$ apt-get install gnupg git
+$ apt-get install gnupg git libcrack2
 ```
 
 On macOS with [homebrew](http://brew.sh) the following will do:
 
 ```bash
-$ brew install gnupg2 git
+$ brew install gnupg2 git cracklib-words
 ```
 
 ### Setup GPG

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Eech4ahRoy2oowi0ohl
 The default action of `gopass` is show. It also accepts the `-c` flag to copy the content of
 the secret directly to the clipboard.
 
-Since it may be dangerous to always display the password on `gopass` calls, the `safecontent` 
-setting may be set to `true` to allow one to display only the rest of the password entries by 
+Since it may be dangerous to always display the password on `gopass` calls, the `safecontent`
+setting may be set to `true` to allow one to display only the rest of the password entries by
 default and display the whole entry, with password, only when the `-f` flag is used.
 
 #### Copy secret to clipboard
@@ -441,7 +441,7 @@ $ gopass ls --flat | dmenu | xargs --no-run-if-empty gopass show | xdotool type 
 On Debian-based Linux systems you should run this command:
 
 ```bash
-$ apt-get install gnupg git libcrack2
+$ apt-get install gnupg git libcrack2-dev
 ```
 
 On macOS with [homebrew](http://brew.sh) the following will do:

--- a/action/check.go
+++ b/action/check.go
@@ -1,0 +1,34 @@
+package action
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/taganaka/go-cracklib"
+	"github.com/urfave/cli"
+)
+
+// Check validates password against cracklib
+func (s *Action) Check(c *cli.Context) error {
+	t, err := s.Store.Tree()
+	if err != nil {
+		return err
+	}
+
+	var out io.Writer
+	out = os.Stdout
+
+	for _, secret := range t.List(0) {
+		content, err := s.Store.Get(secret)
+		if err != nil {
+			return err
+		}
+
+		if m, ok := cracklib.FascistCheck(string(content)); !ok {
+			fmt.Fprintf(out, "Weak password for %s: %s\n", secret, m)
+		}
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -158,6 +158,12 @@ func main() {
 			},
 		},
 		{
+			Name:        "check",
+			Usage:       "Check passwords for common flaws",
+			Description: "To check passwords for common flaws (e.g. too short or from a dictionary)",
+			Action:      action.Check,
+		},
+		{
 			Name:        "clone",
 			Usage:       "Clone a new store",
 			Description: "To clone a remote repo",

--- a/tests/check_test.go
+++ b/tests/check_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheck(t *testing.T) {
+	ts := newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+	ts.initSecrets("")
+
+	list := `Weak password for fixed/secret: it is too short`
+	out, err := ts.run("check")
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(list), out)
+}

--- a/vendor/github.com/taganaka/go-cracklib/README.md
+++ b/vendor/github.com/taganaka/go-cracklib/README.md
@@ -1,0 +1,27 @@
+# Go cracklib binding
+
+A Golang binding for [cracklib](https://github.com/cracklib/cracklib)
+
+## Install
+
+### Linux & Mac OS X
+
+Install Go and cracklib, you might want to install both of them via `apt-get` or `homebrew`.
+
+Mac
+
+`brew install cracklib`
+
+Linux Debian / Ubuntu
+
+`apt-get install cracklib-dev`
+
+```
+go get github.com/taganaka/go-cracklib
+cd $GOPATH/src/github.com/taganaka/go-cracklib/samples
+go run cracklib-ckeck.go
+```
+
+### Author:
+
+Francesco Laurita <https://github.com/taganaka>

--- a/vendor/github.com/taganaka/go-cracklib/cracklib.go
+++ b/vendor/github.com/taganaka/go-cracklib/cracklib.go
@@ -1,0 +1,49 @@
+// Package cracklib provides a Golang binding for cracklib
+// https://github.com/cracklib/cracklib
+package cracklib
+
+// #cgo LDFLAGS: -lcrack
+// #include <stdlib.h>
+// #include <crack.h>
+import "C"
+import "unsafe"
+
+// FascistCheck checks a potential password for guessability
+// It returns an error message and a boolean value
+// The error message will be "" if ok is true
+func FascistCheck(pw string) (message string, ok bool) {
+	path := C.GetDefaultCracklibDict()
+	pwptr := C.CString(pw)
+	defer C.free(unsafe.Pointer(pwptr))
+	v := C.FascistCheck(pwptr, path)
+	message = C.GoString(v)
+	if message != "" {
+		return message, false
+	}
+	return "", true
+}
+
+// FascistCheckUser executes tests against an arbitrary user
+// It returns an error message and a boolean value
+// The error message will be "" if ok is true
+func FascistCheckUser(pw string, user string) (message string, ok bool) {
+	path := C.GetDefaultCracklibDict()
+	pwptr := C.CString(pw)
+	defer C.free(unsafe.Pointer(pwptr))
+	userptr := C.CString(user)
+	defer C.free(unsafe.Pointer(userptr))
+	v := C.FascistCheckUser(pwptr, path, userptr, nil)
+	message = C.GoString(v)
+	if message != "" {
+		return message, false
+	}
+	return "", true
+}
+
+// extern const char *FascistCheck(const char *pw, const char *dictpath);
+// extern const char *FascistCheckUser(const char *pw, const char *dictpath,
+// 				    const char *user, const char *gecos);
+//
+// /* This function returns the compiled in value for DEFAULT_CRACKLIB_DICT.
+//  */
+// extern const char *GetDefaultCracklibDict(void);

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -137,6 +137,12 @@
 			"revisionTime": "2016-09-25T22:06:09Z"
 		},
 		{
+			"checksumSHA1": "wmQr1Ztgk4MijeCkPsUfydPXj0U=",
+			"path": "github.com/taganaka/go-cracklib",
+			"revision": "a3ad93ec48b8c5ebe9e0aa98d00814913aeb0369",
+			"revisionTime": "2016-03-06T06:52:24Z"
+		},
+		{
 			"checksumSHA1": "LMu1NsthSqcXfKu0m6YGPAmwBcY=",
 			"path": "github.com/urfave/cli",
 			"revision": "0bdeddeeb0f650497d603c4ad7b20cfe685682f6",


### PR DESCRIPTION
`gopass check` validates known passwords against cracklib for common flaws,
like being too short or coming from a dictionary/word-list.

This currently requires linking against libcrack2, as I'm not aware of a Golang
implementation of cracklib.