### PR TITLE
Added `gopass audit` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Eech4ahRoy2oowi0ohl
 The default action of `gopass` is show. It also accepts the `-c` flag to copy the content of
 the secret directly to the clipboard.
 
-Since it may be dangerous to always display the password on `gopass` calls, the `safecontent` 
-setting may be set to `true` to allow one to display only the rest of the password entries by 
+Since it may be dangerous to always display the password on `gopass` calls, the `safecontent`
+setting may be set to `true` to allow one to display only the rest of the password entries by
 default and display the whole entry, with password, only when the `-f` flag is used.
 
 #### Copy secret to clipboard
@@ -203,6 +203,16 @@ We also support `pull before push` to reduce the change of `rejected` pushes whe
 
 ```bash
 $ gopass config autopull true
+```
+
+### Check Passwords for Common Flaws
+
+gopass can check your passwords for common flaws, like being too short or coming
+from a dictionary.
+
+```bash
+$ gopass audit
+Weak password for golang.org/gopher: it is too short
 ```
 
 ### Support for Binary Content

--- a/action/audit.go
+++ b/action/audit.go
@@ -1,0 +1,41 @@
+package action
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/muesli/crunchy"
+	"github.com/urfave/cli"
+)
+
+// Audit validates passwords against common flaws
+func (s *Action) Audit(c *cli.Context) error {
+	t, err := s.Store.Tree()
+	if err != nil {
+		return err
+	}
+
+	validator := crunchy.NewValidator()
+	var out io.Writer
+	out = os.Stdout
+
+	foundWeakPasswords := false
+	for _, secret := range t.List(0) {
+		content, err := s.Store.Get(secret)
+		if err != nil {
+			return err
+		}
+
+		if err = validator.Check(string(content)); err != nil {
+			foundWeakPasswords = true
+			fmt.Fprintf(out, "Detected weak password for %s: %v\n", secret, err)
+		}
+	}
+
+	if !foundWeakPasswords {
+		fmt.Fprintln(out, "No weak passwords detected.")
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -108,6 +108,12 @@ func main() {
 
 	app.Commands = []cli.Command{
 		{
+			Name:        "audit",
+			Usage:       "Audit passwords for common flaws",
+			Description: "To check passwords for common flaws (e.g. too short or from a dictionary)",
+			Action:      action.Audit,
+		},
+		{
 			Name:    "binary",
 			Usage:   "Work with binary blobs",
 			Aliases: []string{"bin"},

--- a/tests/audit_test.go
+++ b/tests/audit_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAudit(t *testing.T) {
+	ts := newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+	ts.initSecrets("")
+
+	list := `Detected weak password for fixed/secret: Password is too short`
+	out, err := ts.run("audit")
+	assert.NoError(t, err)
+	assert.Equal(t, strings.TrimSpace(list), out)
+}

--- a/vendor/github.com/muesli/crunchy/LICENSE
+++ b/vendor/github.com/muesli/crunchy/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Christian Muehlhaeuser
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/muesli/crunchy/README.md
+++ b/vendor/github.com/muesli/crunchy/README.md
@@ -1,0 +1,68 @@
+crunchy
+=======
+
+Finds common flaws in passwords. Like cracklib, but written in Go.
+
+Detects:
+ - Empty passwords: `ErrEmpty`
+ - Too short passwords: `ErrTooShort`
+ - Too few different characters, like "aabbccdd": `ErrTooFewChars`
+ - Systematic passwords, like "abcdefgh" or "87654321": `ErrTooSystematic`
+ - Passwords from a dictionary / wordlist: `ErrDictionary`
+ - Mangled / reversed passwords, like "p@ssw0rd" or "drowssap": `ErrMangledDictionary`
+ - Hashed dictionary words, like "5f4dcc3b5aa765d61d8327deb882cf99" (the md5sum of "password"): `ErrHashedDictionary`
+
+Your system dictionaries from /usr/share/dict will be indexed. If no dictionaries were found, crunchy only relies on the
+regular sanity checks (ErrEmpty, ErrTooShort and ErrTooSystematic). On Ubuntu it is recommended to install the wordlists
+distributed with `cracklib-runtime`, on macOS you can install `cracklib-words` from brew. You could also install various
+other language dictionaries or wordlists, e.g. from skullsecurity.org.
+
+crunchy uses the WagnerFischer algorithm to find mangled passwords in your dictionaries.
+
+## Installation
+
+Make sure you have a working Go environment. See the [install instructions](http://golang.org/doc/install.html).
+
+To install crunchy, simply run:
+
+    go get github.com/muesli/crunchy
+
+To compile it from source:
+
+    cd $GOPATH/src/github.com/muesli/crunchy
+    go get -u -v
+    go build && go test -v
+
+## Example
+```go
+package main
+
+import (
+	"github.com/muesli/crunchy"
+	"fmt"
+)
+
+func main() {
+    validator := crunchy.NewValidator()
+    // there's also crunchy.NewValidatorWithOpts()
+
+    err := validator.Check("12345678")
+    if err != nil {
+        fmt.Printf("The password '%s' is considered unsafe: %v\n", "12345678", err)
+    }
+
+    err = validator.Check("d1924ce3d0510b2b2b4604c99453e2e1")
+    if err == nil {
+        // Password is considered acceptable
+        ...
+    }
+}
+```
+
+## Development
+
+API docs can be found [here](http://godoc.org/github.com/muesli/crunchy).
+
+[![Build Status](https://secure.travis-ci.org/muesli/crunchy.png)](http://travis-ci.org/muesli/crunchy)
+[![Coverage Status](https://coveralls.io/repos/github/muesli/crunchy/badge.svg?branch=master)](https://coveralls.io/github/muesli/crunchy?branch=master)
+[![Go ReportCard](http://goreportcard.com/badge/muesli/crunchy)](http://goreportcard.com/report/muesli/crunchy)

--- a/vendor/github.com/muesli/crunchy/crunchy.go
+++ b/vendor/github.com/muesli/crunchy/crunchy.go
@@ -1,0 +1,223 @@
+package crunchy
+
+import (
+	"encoding/hex"
+	"errors"
+	"hash"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/xrash/smetrics"
+)
+
+var (
+	// ErrEmpty gets returned when the password is empty or all whitespace
+	ErrEmpty = errors.New("Password is empty or all whitespace")
+	// ErrTooShort gets returned when the password is not long enough
+	ErrTooShort = errors.New("Password is too short")
+	// ErrTooFewChars gets returned when the password does not contain enough unique characters
+	ErrTooFewChars = errors.New("Password does not contain enough different/unique characters")
+	// ErrTooSystematic gets returned when the password is too systematic (e.g. 123456, abcdef)
+	ErrTooSystematic = errors.New("Password is too systematic")
+	// ErrDictionary gets returned when the password is found in a dictionary
+	ErrDictionary = errors.New("Password is too common / from a dictionary")
+	// ErrMangledDictionary gets returned when the password is mangled, but found in a dictionary
+	ErrMangledDictionary = errors.New("Password is mangled, but too common / from a dictionary")
+	// ErrHashedDictionary gets returned when the password is hashed, but found in a dictionary
+	ErrHashedDictionary = errors.New("Password is hashed, but too common / from a dictionary")
+)
+
+// Validator is used to setup a new password validator with options and dictionaries
+type Validator struct {
+	options     Options
+	once        sync.Once
+	words       map[string]struct{}
+	hashedWords map[string]string
+}
+
+// Options contains all the settings for a Validator
+type Options struct {
+	// MinLength is the minimum length required for a valid password (>=1, default is 8)
+	MinLength int
+	// MinDiff is the minimum amount of unique characters required for a valid password (>=1, default is 5)
+	MinDiff int
+	// MinDist is the minimum WagnerFischer distance for mangled password dictionary lookups (>=0, default is 3)
+	MinDist int
+	// Hashers will be used to find hashed passwords in dictionaries
+	Hashers []hash.Hash
+	// DictionaryPath contains all the dictionaries that will be parsed
+	DictionaryPath string // = "/usr/share/dict"
+}
+
+// NewValidator returns a new password validator with default settings
+func NewValidator() *Validator {
+	return NewValidatorWithOpts(Options{
+		MinDist:        -1,
+		DictionaryPath: "/usr/share/dict"})
+}
+
+// NewValidatorWithOpts returns a new password validator with custom settings
+func NewValidatorWithOpts(options Options) *Validator {
+	if options.MinLength <= 0 {
+		options.MinLength = 8
+	}
+	if options.MinDiff <= 0 {
+		options.MinDiff = 5
+	}
+	if options.MinDist < 0 {
+		options.MinDist = 3
+	}
+
+	return &Validator{
+		options:     options,
+		words:       make(map[string]struct{}),
+		hashedWords: make(map[string]string),
+	}
+}
+
+// countUniqueChars returns the amount of unique runes in a string
+func countUniqueChars(s string) int {
+	m := make(map[rune]struct{})
+
+	for _, c := range s {
+		if _, ok := m[c]; !ok {
+			m[c] = struct{}{}
+		}
+	}
+
+	return len(m)
+}
+
+// countSystematicChars returns how many runes in a string are part of a sequence ('abcdef', '654321')
+func countSystematicChars(s string) int {
+	var x int
+	rs := []rune(s)
+
+	for i, c := range rs {
+		if i == 0 {
+			continue
+		}
+		if c == rs[i-1]+1 || c == rs[i-1]-1 {
+			x++
+		}
+	}
+
+	return x
+}
+
+// reverse returns the reversed form of a string
+func reverse(s string) string {
+	rs := []rune(s)
+	for i, j := 0, len(rs)-1; i < j; i, j = i+1, j-1 {
+		rs[i], rs[j] = rs[j], rs[i]
+	}
+	return string(rs)
+}
+
+// normalize returns the trimmed and lowercase version of a string
+func normalize(s string) string {
+	return strings.TrimSpace(strings.ToLower(s))
+}
+
+// hashsum returns the hashed sum of a string
+func hashsum(s string, hasher hash.Hash) string {
+	hasher.Reset()
+	hasher.Write([]byte(s))
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+// indexDictionaries parses dictionaries/wordlists
+func (v *Validator) indexDictionaries() {
+	if v.options.DictionaryPath == "" {
+		return
+	}
+
+	dicts, err := filepath.Glob(filepath.Join(v.options.DictionaryPath, "*"))
+	if err != nil {
+		return
+	}
+
+	for _, dict := range dicts {
+		buf, err := ioutil.ReadFile(dict)
+		if err != nil {
+			continue
+		}
+
+		for _, word := range strings.Split(string(buf), "\n") {
+			nw := normalize(word)
+
+			// if a word is smaller than the minimum length minus the minimum distance
+			// then any collisons would have been rejected by pre-dictionary checks
+			if len(nw) >= v.options.MinLength-v.options.MinDist {
+				v.words[nw] = struct{}{}
+			}
+
+			for _, hasher := range v.options.Hashers {
+				v.hashedWords[hashsum(nw, hasher)] = nw
+			}
+		}
+	}
+}
+
+// foundInDictionaries returns whether a (mangled) string exists in the indexed dictionaries
+func (v *Validator) foundInDictionaries(s string) (string, error) {
+	v.once.Do(v.indexDictionaries)
+
+	pw := normalize(s)   // normalized password
+	revpw := reverse(pw) // reversed password
+
+	// let's check perfect matches first
+	if _, ok := v.words[pw]; ok {
+		return pw, ErrDictionary
+	}
+	if _, ok := v.words[revpw]; ok {
+		return revpw, ErrMangledDictionary
+	}
+
+	// find hashed dictionary entries
+	if _, ok := v.hashedWords[pw]; ok {
+		return pw, ErrHashedDictionary
+	}
+
+	// find mangled / reversed passwords
+	for word := range v.words {
+		if dist := smetrics.WagnerFischer(word, pw, 1, 1, 1); dist <= v.options.MinDist {
+			// fmt.Printf("%s is too similar to %s: %d\n", pw, word, dist)
+			return word, ErrMangledDictionary
+		}
+		if dist := smetrics.WagnerFischer(word, revpw, 1, 1, 1); dist <= v.options.MinDist {
+			// fmt.Printf("Reversed %s (%s) is too similar to %s: %d\n", pw, revpw, word, dist)
+			return word, ErrMangledDictionary
+		}
+	}
+
+	return "", nil
+}
+
+// Check validates a password for common flaws
+// It returns nil if the password is considered acceptable.
+func (v *Validator) Check(password string) error {
+	if strings.TrimSpace(password) == "" {
+		return ErrEmpty
+	}
+	if len(password) < v.options.MinLength {
+		return ErrTooShort
+	}
+	if countUniqueChars(password) < v.options.MinDiff {
+		return ErrTooFewChars
+	}
+
+	// Inspired by cracklib
+	maxrepeat := 3.0 + (0.09 * float64(len(password)))
+	if countSystematicChars(password) > int(maxrepeat) {
+		return ErrTooSystematic
+	}
+
+	if _, err := v.foundInDictionaries(password); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/github.com/xrash/smetrics/LICENSE
+++ b/vendor/github.com/xrash/smetrics/LICENSE
@@ -1,0 +1,21 @@
+Copyright (C) 2016 Felipe da Cunha Gonçalves
+All Rights Reserved.
+
+MIT LICENSE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/xrash/smetrics/README.md
+++ b/vendor/github.com/xrash/smetrics/README.md
@@ -1,0 +1,120 @@
+# String metrics
+
+This library contains implementations of the Levenshtein distance, Jaro-Winkler and Soundex algorithms written in Go (golang). Other algorithms related with string metrics (or string similarity, whatever) are welcome.
+
+* master: [![Build Status](https://travis-ci.org/xrash/smetrics.svg?branch=master)](http://travis-ci.org/xrash/smetrics)
+
+# Algorithms
+
+## WagnerFischer
+
+        func WagnerFischer(a, b string, icost, dcost, scost int) int
+
+The Wagner-Fischer algorithm for calculating the Levenshtein distance. It runs on O(mn) and needs O(2m) space where m is the size of the smallest string. This is kinda optimized so it should be used in most cases.
+
+The first two parameters are the two strings to be compared. The last three parameters are the insertion cost, the deletion cost and the substitution cost. These are normally defined as 1, 1 and 2.
+
+#### Examples:
+
+        smetrics.WagnerFischer("POTATO", "POTATTO", 1, 1, 2)
+		>> 1, delete the second T on POTATTO
+
+        smetrics.WagnerFischer("MOUSE", "HOUSE", 2, 2, 4)
+		>> 4, substitute M for H
+
+## Ukkonen
+
+        func Ukkonen(a, b string, icost, dcost, scost int) int
+
+The Ukkonen algorithm for calculating the Levenshtein distance. The algorithm is described [here](http://www.cs.helsinki.fi/u/ukkonen/InfCont85.PDF). It runs on O(t . min(m, n)) where t is the actual distance between strings a and b, so this version should be preferred over the WagnerFischer for strings **very** similar. In practice, it's slower most of the times. It needs O(min(t, m, n)) space.
+
+The first two parameters are the two strings to be compared. The last three parameters are the insertion cost, the deletion cost and the substitution cost. These are normally defined as 1, 1 and 2.
+
+#### Examples:
+
+        smetrics.Ukkonen("POTATO", "POTATTO", 1, 1, 2)
+		>> 1, delete the second T on POTATTO
+
+        smetrics.Ukkonen("MOUSE", "HOUSE", 2, 2, 4)
+		>> 4, substitute M for H
+
+## Jaro
+
+        func Jaro(a, b string) float64
+
+The Jaro distance. It is not very accurate, therefore you should prefer the JaroWinkler optimized version.
+
+#### Examples:
+
+        smetrics.Jaro("AL", "AL")
+		>> 1, equal strings
+
+        smetrics.Jaro("MARTHA", "MARHTA")
+		>> 0.9444444444444445, very likely a typo
+
+        smetrics.Jaro("JONES", "JOHNSON")
+		>> 0.7904761904761904
+
+## JaroWinkler
+
+        func JaroWinkler(a, b string, boostThreshold float64, prefixSize int) float64
+
+The JaroWinkler distance. JaroWinkler returns a number between 0 and 1 where 1 means perfectly equal and 0 means completely different. It is commonly used on Record Linkage stuff, thus it tries to be accurate for real names and common typos. You should consider it on data such as person names and street names.
+
+JaroWinkler is a more accurate version of the Jaro algorithm. It works by boosting the score of exact matches at the beginning of the strings. By doing this, Winkler says that typos are less common to happen at the beginning. For this to happen, it introduces two more parameters: the boostThreshold and the prefixSize. These are commonly set to 0.7 and 4, respectively.
+
+#### Examples:
+
+        smetrics.JaroWinkler("AL", "AL", 0.7, 4)
+		>> 1, equal strings
+
+        smetrics.JaroWinkler("MARTHA", "MARHTA", 0.7, 4)
+		>> 0.9611111111111111, very likely a typo
+
+        smetrics.JaroWinkler("JONES", "JOHNSON", 0.7, 4)
+		>> 0.8323809523809523
+
+## Soundex
+
+        func Soundex(s string) string
+
+The Soundex encoding. It is a phonetic algorithm that considers how the words sound in english. Soundex maps a name to a 4-byte string consisting of the first letter of the original string and three numbers. Strings that sound similar should map to the same thing.
+
+#### Examples:
+
+        smetrics.Soundex("Euler")
+		>> E460
+
+        smetrics.Soundex("Ellery")
+		>> E460
+
+        smetrics.Soundex("Lloyd")
+		>> L300
+
+        smetrics.Soundex("Ladd")
+		>> L300
+
+## Hamming
+
+        func Hamming(a, b string) (int, error)
+
+The Hamming distance is simply the minimum number of substitutions required to change one string into the other. Both strings must have the same size, of the function returns an error.
+
+#### Examples:
+
+        smetrics.Hamming("aaa", "aaa")
+		>> 0, nil
+
+        smetrics.Hamming("aaa", "aab")
+		>> 1, nil
+
+        smetrics.Hamming("aaaa", "a")
+		>> -1, error
+
+# TODO
+
+- Accept cost functions instead of constant values in every Levenshtein implementation.
+
+- Make a better interface.
+
+- Moar algos!

--- a/vendor/github.com/xrash/smetrics/doc.go
+++ b/vendor/github.com/xrash/smetrics/doc.go
@@ -1,0 +1,121 @@
+/*
+# String metrics
+
+This library contains implementations of the Levenshtein distance, Jaro-Winkler and Soundex algorithms written in Go (golang). Other algorithms related with string metrics (or string similarity, whatever) are welcome.
+
+# Algorithms
+
+## WagnerFischer
+
+        func WagnerFischer(a, b string, icost, dcost, scost int) int
+
+The Wagner-Fischer algorithm for calculating the Levenshtein distance. It runs on O(mn) and the currently non-optimized version also needs O(mn) space. This version should be preferred over the Ukkonen one for short strings.
+
+The first two parameters are the two strings to be compared. The last three parameters are the insertion cost, the deletion cost and the substitution cost. These are normally defined as 1, 1 and 2.
+
+#### Examples:
+
+        smetrics.WagnerFischer("POTATO", "POTATTO", 1, 1, 2)
+		>> 1, delete the second T on POTATTO
+
+        smetrics.WagnerFischer("MOUSE", "HOUSE", 2, 2, 4)
+		>> 4, substitute M for H
+
+## Ukkonen
+
+        func Ukkonen(a, b string, icost, dcost, scost int) int
+
+The Ukkonen algorithm for calculating the Levenshtein distance. The algorithm is described [here](http://www.cs.helsinki.fi/u/ukkonen/InfCont85.PDF). It runs on O(t . min(m, n)) where t is the actual distance between strings a and b. It needs O(min(t, m, n)) space. This version should be preferred over the WagnerFischer one for very similar strings.
+
+The first two parameters are the two strings to be compared. The last three parameters are the insertion cost, the deletion cost and the substitution cost. These are normally defined as 1, 1 and 2.
+
+#### Examples:
+
+        smetrics.Ukkonen("POTATO", "POTATTO", 1, 1, 2)
+		>> 1, delete the second T on POTATTO
+
+        smetrics.Ukkonen("MOUSE", "HOUSE", 2, 2, 4)
+		>> 4, substitute M for H
+
+## Jaro
+
+        func Jaro(a, b string) float64
+
+The Jaro distance. It is not very accurate, therefore you should prefer the JaroWinkler optimized version.
+
+#### Examples:
+
+        smetrics.Jaro("AL", "AL")
+		>> 1, equal strings
+
+        smetrics.Jaro("MARTHA", "MARHTA")
+		>> 0.9444444444444445, very likely a typo
+
+        smetrics.Jaro("JONES", "JOHNSON")
+		>> 0.7904761904761904
+
+## JaroWinkler
+
+        func JaroWinkler(a, b string, boostThreshold float64, prefixSize int) float64
+
+The JaroWinkler distance. JaroWinkler returns a number between 0 and 1 where 1 means perfectly equal and 0 means completely different. It is commonly used on Record Linkage stuff, thus it tries to be accurate for real names and common typos. You should consider it on data such as person names and street names.
+
+JaroWinkler is a more accurate version of the Jaro algorithm. It works by boosting the score of exact matches at the beginning of the strings. By doing this, Winkler says that typos are less common to happen at the beginning. For this to happen, it introduces two more parameters: the boostThreshold and the prefixSize. These are commonly set to 0.7 and 4, respectively.
+
+#### Examples:
+
+        smetrics.JaroWinkler("AL", "AL", 0.7, 4)
+		>> 1, equal strings
+
+        smetrics.JaroWinkler("MARTHA", "MARHTA", 0.7, 4)
+		>> 0.9611111111111111, very likely a typo
+
+        smetrics.JaroWinkler("JONES", "JOHNSON", 0.7, 4)
+		>> 0.8323809523809523
+
+## Soundex
+
+        func Soundex(s string) string
+
+The Soundex encoding. It is a phonetic algorithm that considers how the words sound in english. Soundex maps a name to a 4-byte string consisting of the first letter of the original string and three numbers. Strings that sound similar should map to the same thing.
+
+#### Examples:
+
+        smetrics.Soundex("Euler")
+		>> E460
+
+        smetrics.Soundex("Ellery")
+		>> E460
+
+        smetrics.Soundex("Lloyd")
+		>> L300
+
+        smetrics.Soundex("Ladd")
+		>> L300
+
+## Hamming
+
+        func Hamming(a, b string) (int, error)
+
+The Hamming distance is simply the minimum number of substitutions required to change one string into the other. Both strings must have the same size, of the function returns an error.
+
+#### Examples:
+
+        smetrics.Hamming("aaa", "aaa")
+		>> 0, nil
+
+        smetrics.Hamming("aaa", "aab")
+		>> 1, nil
+
+        smetrics.Hamming("aaaa", "a")
+		>> -1, error
+
+# TODO
+
+- Optimize WagnerFischer for memory; currently it stores the whole matrix and so it needs O(mn) space. Only the previous row of the matrix needs to be stored, so it can be easily optimized to use O(m) space.
+
+- Accept cost functions instead of constant values in every Levenshtein implementation.
+
+- Moar algos!
+*/
+package smetrics

--- a/vendor/github.com/xrash/smetrics/hamming.go
+++ b/vendor/github.com/xrash/smetrics/hamming.go
@@ -1,0 +1,24 @@
+package smetrics
+
+import (
+	"fmt"
+)
+
+func Hamming(a, b string) (int, error) {
+	al := len(a)
+	bl := len(b)
+
+	if al != bl {
+		return -1, fmt.Errorf("strings are not equal (len(a)=%d, len(b)=%d)", al, bl)
+	}
+
+	var difference = 0
+
+	for i := range a {
+		if a[i] != b[i] {
+			difference = difference + 1
+		}
+	}
+
+	return difference, nil
+}

--- a/vendor/github.com/xrash/smetrics/jaro-winkler.go
+++ b/vendor/github.com/xrash/smetrics/jaro-winkler.go
@@ -1,0 +1,24 @@
+package smetrics
+
+import (
+	"math"
+)
+
+func JaroWinkler(a, b string, boostThreshold float64, prefixSize int) float64 {
+	j := Jaro(a, b)
+
+	if j <= boostThreshold {
+		return j
+	}
+
+	prefixSize = int(math.Min(float64(len(a)), math.Min(float64(prefixSize), float64(len(b)))))
+
+	var prefixMatch float64
+	for i := 0; i < prefixSize; i++ {
+		if a[i] == b[i] {
+			prefixMatch++
+		}
+	}
+
+	return j + 0.1*prefixMatch*(1.0-j)
+}

--- a/vendor/github.com/xrash/smetrics/jaro.go
+++ b/vendor/github.com/xrash/smetrics/jaro.go
@@ -1,0 +1,44 @@
+package smetrics
+
+import (
+	"math"
+)
+
+func Jaro(a, b string) float64 {
+	la := float64(len(a))
+	lb := float64(len(b))
+
+	// match range = max(len(a), len(b)) / 2 - 1
+	matchRange := int(math.Floor(math.Max(la, lb)/2.0)) - 1
+	matchRange = int(math.Max(0, float64(matchRange-1)))
+	var matches, halfs float64
+	transposed := make([]bool, len(b))
+
+	for i := 0; i < len(a); i++ {
+		start := int(math.Max(0, float64(i-matchRange)))
+		end := int(math.Min(lb-1, float64(i+matchRange)))
+
+		for j := start; j <= end; j++ {
+			if transposed[j] {
+				continue
+			}
+
+			if a[i] == b[j] {
+				if i != j {
+					halfs++
+				}
+				matches++
+				transposed[j] = true
+				break
+			}
+		}
+	}
+
+	if matches == 0 {
+		return 0
+	}
+
+	transposes := math.Floor(float64(halfs / 2))
+
+	return ((matches / la) + (matches / lb) + (matches-transposes)/matches) / 3.0
+}

--- a/vendor/github.com/xrash/smetrics/soundex.go
+++ b/vendor/github.com/xrash/smetrics/soundex.go
@@ -1,0 +1,40 @@
+package smetrics
+
+import (
+	"strings"
+)
+
+func Soundex(s string) string {
+	m := map[byte]string{
+		'B': "1", 'P': "1", 'F': "1", 'V': "1",
+		'C': "2", 'S': "2", 'K': "2", 'G': "2", 'J': "2", 'Q': "2", 'X': "2", 'Z': "2",
+		'D': "3", 'T': "3",
+		'L': "4",
+		'M': "5", 'N': "5",
+		'R': "6",
+	}
+
+	s = strings.ToUpper(s)
+
+	r := string(s[0])
+	p := s[0]
+	for i := 1; i < len(s) && len(r) < 4; i++ {
+		c := s[i]
+
+		if (c < 'A' || c > 'Z') || (c == p) {
+			continue
+		}
+
+		p = c
+
+		if n, ok := m[c]; ok {
+			r += n
+		}
+	}
+
+	for i := len(r); i < 4; i++ {
+		r += "0"
+	}
+
+	return r
+}

--- a/vendor/github.com/xrash/smetrics/ukkonen.go
+++ b/vendor/github.com/xrash/smetrics/ukkonen.go
@@ -1,0 +1,92 @@
+package smetrics
+
+import (
+	"math"
+)
+
+func Ukkonen(a, b string, icost, dcost, scost int) int {
+	var lowerCost int
+
+	if icost < dcost && icost < scost {
+		lowerCost = icost
+	} else if dcost < scost {
+		lowerCost = dcost
+	} else {
+		lowerCost = scost
+	}
+
+	infinite := math.MaxInt32 / 2
+
+	var r []int
+	var k, kprime, p, t int
+	var ins, del, sub int
+
+	if len(a) > len(b) {
+		t = (len(a) - len(b) + 1) * lowerCost
+	} else {
+		t = (len(b) - len(a) + 1) * lowerCost
+	}
+
+	for {
+		if (t / lowerCost) < (len(b) - len(a)) {
+			continue
+		}
+
+		// This is the right damn thing since the original Ukkonen
+		// paper minimizes the expression result only, but the uncommented version
+		// doesn't need to deal with floats so it's faster.
+		// p = int(math.Floor(0.5*((float64(t)/float64(lowerCost)) - float64(len(b) - len(a)))))
+		p = ((t / lowerCost) - (len(b) - len(a))) / 2
+
+		k = -p
+		kprime = k
+
+		rowlength := (len(b) - len(a)) + (2 * p)
+
+		r = make([]int, rowlength+2)
+
+		for i := 0; i < rowlength+2; i++ {
+			r[i] = infinite
+		}
+
+		for i := 0; i <= len(a); i++ {
+			for j := 0; j <= rowlength; j++ {
+				if i == j+k && i == 0 {
+					r[j] = 0
+				} else {
+					if j-1 < 0 {
+						ins = infinite
+					} else {
+						ins = r[j-1] + icost
+					}
+
+					del = r[j+1] + dcost
+					sub = r[j] + scost
+
+					if i-1 < 0 || i-1 >= len(a) || j+k-1 >= len(b) || j+k-1 < 0 {
+						sub = infinite
+					} else if a[i-1] == b[j+k-1] {
+						sub = r[j]
+					}
+
+					if ins < del && ins < sub {
+						r[j] = ins
+					} else if del < sub {
+						r[j] = del
+					} else {
+						r[j] = sub
+					}
+				}
+			}
+			k++
+		}
+
+		if r[(len(b)-len(a))+(2*p)+kprime] <= t {
+			break
+		} else {
+			t *= 2
+		}
+	}
+
+	return r[(len(b)-len(a))+(2*p)+kprime]
+}

--- a/vendor/github.com/xrash/smetrics/wagner-fischer.go
+++ b/vendor/github.com/xrash/smetrics/wagner-fischer.go
@@ -1,0 +1,45 @@
+package smetrics
+
+func WagnerFischer(a, b string, icost, dcost, scost int) int {
+	// Allocate both rows.
+	row1 := make([]int, len(b)+1)
+	row2 := make([]int, len(b)+1)
+	var tmp []int
+
+	// Initialize the first row.
+	for i := 1; i <= len(b); i++ {
+		row1[i] = i * icost
+	}
+
+	// For each row...
+	for i := 1; i <= len(a); i++ {
+		row2[0] = i * dcost
+
+		// For each column...
+		for j := 1; j <= len(b); j++ {
+			if a[i-1] == b[j-1] {
+				row2[j] = row1[j-1]
+			} else {
+				ins := row2[j-1] + icost
+				del := row1[j] + dcost
+				sub := row1[j-1] + scost
+
+				if ins < del && ins < sub {
+					row2[j] = ins
+				} else if del < sub {
+					row2[j] = del
+				} else {
+					row2[j] = sub
+				}
+			}
+		}
+
+		// Swap the rows at the end of each row.
+		tmp = row1
+		row1 = row2
+		row2 = tmp
+	}
+
+	// Because we swapped the rows, the final result is in row1 instead of row2.
+	return row1[len(row1)-1]
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -82,6 +82,12 @@
 			"revisionTime": "2016-11-23T14:36:37Z"
 		},
 		{
+			"checksumSHA1": "LEQvE0mbFFmQGEgSkT2UYSs2tKk=",
+			"path": "github.com/muesli/crunchy",
+			"revision": "ea7a2096c31f029ee66e245338c2920b14724e7e",
+			"revisionTime": "2017-08-03T14:56:15Z"
+		},
+		{
 			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
@@ -141,6 +147,12 @@
 			"path": "github.com/urfave/cli",
 			"revision": "0bdeddeeb0f650497d603c4ad7b20cfe685682f6",
 			"revisionTime": "2016-11-22T04:36:10Z"
+		},
+		{
+			"checksumSHA1": "ZaOvCn/mlhJZ00hxTgTJ6gRn3MQ=",
+			"path": "github.com/xrash/smetrics",
+			"revision": "a3153f7040e90324c58c6287535e26a0ac5c1cc1",
+			"revisionTime": "2017-02-18T16:04:15Z"
 		},
 		{
 			"checksumSHA1": "xiderUuvye8Kpn7yX3niiJg32bE=",


### PR DESCRIPTION
`gopass audit` validates known passwords against common flaws,
like being too short or systematic.

This uses my own Golang implementation of cracklib: https://github.com/muesli/crunchy

Wordlist / dictionary checking is still on my TODO-list, but the API should remain
stable for that. A simple vendor-bump would be enough in that case.

EDIT: renamed to `gopass audit` after lengthy discussion below, to avoid confusion.