### PR TITLE
Use fmt.Print without an output buffer in action/audit

### DIFF
--- a/action/audit.go
+++ b/action/audit.go
@@ -2,8 +2,6 @@ package action
 
 import (
 	"fmt"
-	"io"
-	"os"
 	"strings"
 
 	"github.com/muesli/crunchy"
@@ -18,11 +16,9 @@ func (s *Action) Audit(c *cli.Context) error {
 	}
 
 	validator := crunchy.NewValidator()
-	var out io.Writer
-	out = os.Stdout
-
 	dupes := make(map[string][]string)
 	foundWeakPasswords := false
+
 	for _, secret := range t.List(0) {
 		content, err := s.Store.Get(secret)
 		if err != nil {
@@ -32,18 +28,18 @@ func (s *Action) Audit(c *cli.Context) error {
 		pw := string(content)
 		if err = validator.Check(pw); err != nil {
 			foundWeakPasswords = true
-			fmt.Fprintf(out, "Detected weak password for %s: %v\n", secret, err)
+			fmt.Printf("Detected weak password for %s: %v\n", secret, err)
 		}
 
 		dupes[pw] = append(dupes[pw], secret)
 	}
 
 	if !foundWeakPasswords {
-		fmt.Fprintln(out, "No weak passwords detected.")
+		fmt.Println("No weak passwords detected.")
 	}
 	for _, dupe := range dupes {
 		if len(dupe) > 1 {
-			fmt.Fprintf(out, "Detected a shared password for %s\n", strings.Join(dupe, ", "))
+			fmt.Printf("Detected a shared password for %s\n", strings.Join(dupe, ", "))
 		}
 	}
 


### PR DESCRIPTION
Got rid of the io.Writer, see remarks in #228.