### PR TITLE
Fixed a few linter warnings in actions

### DIFF
--- a/action/clihelper.go
+++ b/action/clihelper.go
@@ -212,8 +212,6 @@ func (s *Action) askForGitConfigUser() (string, string, error) {
 
 	for _, key := range keyList {
 		for _, identity := range key.Identities {
-			useCurrent = false
-
 			if !s.isTerm {
 				return identity.Name, identity.Email, nil
 			}

--- a/action/edit.go
+++ b/action/edit.go
@@ -70,7 +70,7 @@ func (s *Action) editor(content []byte) ([]byte, error) {
 		}
 	}()
 
-	if _, err := tmpfile.Write([]byte(content)); err != nil {
+	if _, err := tmpfile.Write(content); err != nil {
 		return []byte{}, fmt.Errorf("failed to write tmpfile to start with %s %v: %s", editor, tmpfile.Name(), err)
 	}
 	if err := tmpfile.Close(); err != nil {

--- a/action/insert.go
+++ b/action/insert.go
@@ -74,7 +74,7 @@ func (s *Action) Insert(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		return s.Store.SetConfirm(name, []byte(content), fmt.Sprintf("Inserted user supplied password with %s", os.Getenv("EDITOR")), confirm)
+		return s.Store.SetConfirm(name, content, fmt.Sprintf("Inserted user supplied password with %s", os.Getenv("EDITOR")), confirm)
 	}
 
 	// if echo mode is requested use a simple string input function


### PR DESCRIPTION
action/clihelper.go:
No need to initialize useCurrent on every loop iteration, it will always be re-set a few lines below.

action/edit.go & action/insert.go:
content is already a []byte, no need to cast/convert it.