### PR TITLE
Updated crunchy, so we can get rid of the max-len check in `gopass audit`

### DIFF
--- a/action/audit.go
+++ b/action/audit.go
@@ -11,10 +11,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-const (
-	maxCheckLength = 256
-)
-
 // Audit validates passwords against common flaws
 func (s *Action) Audit(c *cli.Context) error {
 	t, err := s.Store.Tree()
@@ -38,10 +34,6 @@ func (s *Action) Audit(c *cli.Context) error {
 		}
 
 		pw := string(content)
-		if len(pw) > maxCheckLength {
-			fmt.Println(color.RedString("Warning: Skipped long secret"))
-			continue
-		}
 		if err = validator.Check(pw); err != nil {
 			foundWeakPasswords = true
 			fmt.Println(color.CyanString("Detected weak password for %s: %v\n", secret, err))

--- a/vendor/github.com/muesli/crunchy/README.md
+++ b/vendor/github.com/muesli/crunchy/README.md
@@ -13,9 +13,9 @@ Detects:
  - Hashed dictionary words, like "5f4dcc3b5aa765d61d8327deb882cf99" (the md5sum of "password"): `ErrHashedDictionary`
 
 Your system dictionaries from /usr/share/dict will be indexed. If no dictionaries were found, crunchy only relies on the
-regular sanity checks (ErrEmpty, ErrTooShort and ErrTooSystematic). On Ubuntu it is recommended to install the wordlists
-distributed with `cracklib-runtime`, on macOS you can install `cracklib-words` from brew. You could also install various
-other language dictionaries or wordlists, e.g. from skullsecurity.org.
+regular sanity checks (ErrEmpty, ErrTooShort, ErrTooFewChars and ErrTooSystematic). On Ubuntu it is recommended to install
+the wordlists distributed with `cracklib-runtime`, on macOS you can install `cracklib-words` from brew. You could also
+install various other language dictionaries or wordlists, e.g. from skullsecurity.org.
 
 crunchy uses the WagnerFischer algorithm to find mangled passwords in your dictionaries.
 

--- a/vendor/github.com/muesli/crunchy/crunchy.go
+++ b/vendor/github.com/muesli/crunchy/crunchy.go
@@ -1,3 +1,10 @@
+/*
+ * crunchy - find common flaws in passwords
+ *     Copyright (c) 2017, Christian Muehlhaeuser <muesli@gmail.com>
+ *
+ *   For license see LICENSE
+ */
+
 package crunchy
 
 import (
@@ -33,6 +40,7 @@ var (
 type Validator struct {
 	options     Options
 	once        sync.Once
+	wordsMaxLen int
 	words       map[string]struct{}
 	hashedWords map[string]string
 }
@@ -47,15 +55,16 @@ type Options struct {
 	MinDist int
 	// Hashers will be used to find hashed passwords in dictionaries
 	Hashers []hash.Hash
-	// DictionaryPath contains all the dictionaries that will be parsed
-	DictionaryPath string // = "/usr/share/dict"
+	// DictionaryPath contains all the dictionaries that will be parsed (default is /usr/share/dict)
+	DictionaryPath string
 }
 
 // NewValidator returns a new password validator with default settings
 func NewValidator() *Validator {
 	return NewValidatorWithOpts(Options{
 		MinDist:        -1,
-		DictionaryPath: "/usr/share/dict"})
+		DictionaryPath: "/usr/share/dict",
+	})
 }
 
 // NewValidatorWithOpts returns a new password validator with custom settings
@@ -147,10 +156,14 @@ func (v *Validator) indexDictionaries() {
 
 		for _, word := range strings.Split(string(buf), "\n") {
 			nw := normalize(word)
+			nwlen := len(nw)
+			if nwlen > v.wordsMaxLen {
+				v.wordsMaxLen = nwlen
+			}
 
 			// if a word is smaller than the minimum length minus the minimum distance
 			// then any collisons would have been rejected by pre-dictionary checks
-			if len(nw) >= v.options.MinLength-v.options.MinDist {
+			if nwlen >= v.options.MinLength-v.options.MinDist {
 				v.words[nw] = struct{}{}
 			}
 
@@ -167,13 +180,17 @@ func (v *Validator) foundInDictionaries(s string) (string, error) {
 
 	pw := normalize(s)   // normalized password
 	revpw := reverse(pw) // reversed password
+	pwlen := len(pw)
 
 	// let's check perfect matches first
-	if _, ok := v.words[pw]; ok {
-		return pw, ErrDictionary
-	}
-	if _, ok := v.words[revpw]; ok {
-		return revpw, ErrMangledDictionary
+	// we can skip this if the pw is longer than the longest word in our dictionary
+	if pwlen <= v.wordsMaxLen {
+		if _, ok := v.words[pw]; ok {
+			return pw, ErrDictionary
+		}
+		if _, ok := v.words[revpw]; ok {
+			return revpw, ErrMangledDictionary
+		}
 	}
 
 	// find hashed dictionary entries
@@ -182,14 +199,15 @@ func (v *Validator) foundInDictionaries(s string) (string, error) {
 	}
 
 	// find mangled / reversed passwords
-	for word := range v.words {
-		if dist := smetrics.WagnerFischer(word, pw, 1, 1, 1); dist <= v.options.MinDist {
-			// fmt.Printf("%s is too similar to %s: %d\n", pw, word, dist)
-			return word, ErrMangledDictionary
-		}
-		if dist := smetrics.WagnerFischer(word, revpw, 1, 1, 1); dist <= v.options.MinDist {
-			// fmt.Printf("Reversed %s (%s) is too similar to %s: %d\n", pw, revpw, word, dist)
-			return word, ErrMangledDictionary
+	// we can skip this if the pw is longer than the longest word plus our minimum distance
+	if pwlen <= v.wordsMaxLen+v.options.MinDist {
+		for word := range v.words {
+			if dist := smetrics.WagnerFischer(word, pw, 1, 1, 1); dist <= v.options.MinDist {
+				return word, ErrMangledDictionary
+			}
+			if dist := smetrics.WagnerFischer(word, revpw, 1, 1, 1); dist <= v.options.MinDist {
+				return word, ErrMangledDictionary
+			}
 		}
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -88,10 +88,10 @@
 			"revisionTime": "2016-11-23T14:36:37Z"
 		},
 		{
-			"checksumSHA1": "LEQvE0mbFFmQGEgSkT2UYSs2tKk=",
+			"checksumSHA1": "zA7bumv9IZ/malDah5mnLu9acrg=",
 			"path": "github.com/muesli/crunchy",
-			"revision": "ea7a2096c31f029ee66e245338c2920b14724e7e",
-			"revisionTime": "2017-08-03T14:56:15Z"
+			"revision": "36b0143650b78f67a2c842b7c924a3ced5a86243",
+			"revisionTime": "2017-08-06T02:11:55Z"
 		},
 		{
 			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",


### PR DESCRIPTION
crunchy now keeps track of the longest word in the indexed dictionaries, so it
can automatically skip dictionary lookups for long passwords.

Depending on the language dictionaries you have installed, the maximum usually
ranges between 24 to 40 characters - anything above that (plus minimum mangling
distance) will be accepted as a valid password after the regular sanity checks.

This means we don't have to guess our `maxCheckLength` and can process longer
secrets even more efficiently.