### PR TITLE
Rewrite auditing to run concurrently with a worker pool

### DIFF
--- a/action/audit.go
+++ b/action/audit.go
@@ -3,7 +3,7 @@ package action
 import (
 	"fmt"
 	"os"
-	"strings"
+	"runtime"
 
 	"github.com/fatih/color"
 	"github.com/muesli/crunchy"
@@ -11,68 +11,125 @@ import (
 	"github.com/urfave/cli"
 )
 
+// AuditedSecret with its name, content a warning message and a pipeline error.
+type AuditedSecret struct {
+	name string
+
+	// the secret's content as a string. Needed for checking for duplicates.
+	content string
+
+	// message to the user about some flaw in the secret
+	message string
+
+	// real error that something in the pipeline went wrong
+	err error
+}
+
 // Audit validates passwords against common flaws
 func (s *Action) Audit(c *cli.Context) error {
 	t, err := s.Store.Tree()
 	if err != nil {
 		return err
 	}
+	list := t.List(0)
 
+	fmt.Printf("Checking %d secrets. This may take some time ...\n", len(list))
+
+	// Jobs are the secrets that still need auditing.
+	jobs := make(chan string)
+
+	// Secrets that have been audited.
+	checked := make(chan AuditedSecret)
+
+	// Spawn workers that run the auditing of all secrets concurrently.
 	validator := crunchy.NewValidator()
-	dupes := make(map[string][]string)
-	foundWeakPasswords := false
+	for worker := 1; worker <= runtime.NumCPU(); worker++ {
+		go s.audit(validator, jobs, checked)
+	}
 
-	pwList := t.List(0)
-	fmt.Printf("Checking %d secrets. This may take some time ...\n", len(pwList))
+	go func() {
+		for _, secret := range list {
+			jobs <- secret
+		}
+		close(jobs)
+	}()
+
+	duplicates := make(map[string][]string)
+	messages := make(map[string][]string)
 
 	bar := &goprogressbar.ProgressBar{
-		Text:    "Secrets checked",
-		Total:   int64(len(pwList)),
-		Current: 0,
-		Width:   120,
+		Total: int64(len(list)),
+		Width: 120,
 	}
-	for _, secret := range pwList {
-		bar.Current++
+
+	i := 0
+	for secret := range checked {
+		duplicates[secret.content] = append(duplicates[secret.content], secret.name)
+
+		if secret.message != "" {
+			messages[secret.message] = append(messages[secret.message], secret.name)
+		}
+
+		i++
+		bar.Current = int64(i)
 		bar.Text = fmt.Sprintf("%d of %d secrets checked", bar.Current, bar.Total)
 		bar.LazyPrint()
 
-		content, err := s.Store.GetFirstLine(secret)
-		if err != nil {
-			bar.Clear()
-			fmt.Println(color.RedString("Failed to retrieve secret '%s': %s", secret, err))
-			continue
+		if i == len(list) {
+			close(checked)
 		}
+	}
+	fmt.Println("") // Print empty line after the progressbar.
 
-		pw := string(content)
-		if err = validator.Check(pw); err != nil {
-			foundWeakPasswords = true
-			bar.Clear()
-			fmt.Println(color.CyanString("Detected weak secret for '%s': %v", secret, err))
+	foundDuplicates := false
+	for _, secrets := range duplicates {
+		if len(secrets) > 1 {
+			foundDuplicates = true
+
+			fmt.Printf(color.CyanString("Detected a shared secret for:\n"))
+			for _, secret := range secrets {
+				fmt.Printf(color.CyanString("\t- %s\n", secret))
+			}
 		}
+	}
 
-		dupes[pw] = append(dupes[pw], secret)
+	if !foundDuplicates {
+		fmt.Println(color.GreenString("No shared secrets found."))
+	}
+
+	foundWeakPasswords := false
+	for msg, secrets := range messages {
+		foundWeakPasswords = true
+		fmt.Printf(color.CyanString("%s:\n", msg))
+		for _, secret := range secrets {
+			fmt.Printf(color.CyanString("\t- %s\n", secret))
+		}
 	}
 
 	if !foundWeakPasswords {
 		fmt.Println(color.GreenString("No weak secrets detected."))
-	} else {
-		bar.Clear()
 	}
 
-	foundDupes := false
-	for _, dupe := range dupes {
-		if len(dupe) > 1 {
-			foundDupes = true
-			fmt.Println(color.CyanString("Detected a shared secret for %s", strings.Join(dupe, ", ")))
-		}
-	}
-	if !foundDupes {
-		fmt.Println(color.GreenString("No shared secrets found."))
-	}
-
-	if foundWeakPasswords || foundDupes {
+	if foundWeakPasswords || foundDuplicates {
 		os.Exit(1)
 	}
 
 	return nil
+}
+
+func (s *Action) audit(validator *crunchy.Validator, secrets <-chan string, checked chan<- AuditedSecret) {
+	for secret := range secrets {
+		content, err := s.Store.GetFirstLine(secret)
+		if err != nil {
+			checked <- AuditedSecret{name: secret, content: string(content), err: err}
+			continue
+		}
+
+		if err := validator.Check(string(content)); err != nil {
+			checked <- AuditedSecret{name: secret, content: string(content), message: err.Error()}
+			continue
+		}
+
+		checked <- AuditedSecret{name: secret, content: string(content)}
+	}
 }

--- a/tests/audit_test.go
+++ b/tests/audit_test.go
@@ -16,5 +16,6 @@ func TestAudit(t *testing.T) {
 	out, err := ts.run("audit")
 	assert.Error(t, err)
 	assert.Contains(t, out, "No shared secrets found")
-	assert.Contains(t, out, "Detected weak secret for 'fixed/secret': Password is too short")
+	assert.Contains(t, out, "Password is too short:")
+	assert.Contains(t, out, "\t- fixed/secret")
 }


### PR DESCRIPTION
I went ahead and re-implemented the audit command.
It's now using a worker pool to decrypt quicker. Sadly it doesn't improve the speed as much as I thought, but still a bit. For 400 secrets it now takes 55s instead of 80s.

I also improved the output because I needed to handle that differently due to the concurrency introduced:

```
Detected weak secret for 'foo/bar1': Password is mangled, but too common / from a dictionary
Detected weak secret for 'foo/bar2': Password is too short
Detected weak secret for 'foo/bar3': Password is mangled, but too common / from a dictionary
Detected weak secret for 'foo/bar4': Password is too short
```
becomes:
```
Password is too short:
        - foo/bar2
        - foo/bar4
Password is mangled, but too common / from a dictionary:
        - foo/bar1
        - foo/bar3
```
@muesli 