### PR TITLE
Document commands working with sub stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In the example above the repository would have been cloned to `$HOME/.password-s
 Afterwards the directory would have been mounted as `work`.
 
 Please note that the repository must contain an already initialized password
-store. You can initialize a new store with `gopass init --store /path/to/store`.
+store. You can initialize a new store with `gopass init --path /path/to/store`.
 
 ### Adding secrets
 
@@ -254,7 +254,26 @@ $ gopass mounts
 $ gopass mounts remove test
 ```
 
-You can initialize a new store using `gopass init --alias mount-point --store /path/to/store`.
+You can initialize a new store using `gopass init --store mount-point --path /path/to/store`.
+
+Where possible sub stores are supported transparently through the path to the
+secret. When specifying the name of a secret it's matched against any mounted
+sub stores and the given action is executed on this store.
+
+Commands that don't accept an secret name, e.g. `gopass recipients add` or
+`gopass init` usually accept a `--store` parameter. Please check the help output
+of each command for more information, e.g. `gopass help init` or
+`gopass recipients help add`.
+
+Commands that support the `--store` flag:
+
+| **Command** | *Example* | Description |
+| ----------- | --------- | ----------- |
+| `gopass git` | `gopass git --store=foo push origin master` | Push all changes in the sub store *foo* to master
+| `gopass git init` | `gopass git init --store=foo` | Initialize git in the sub store *foo*
+| `gopass init` | `gopass init --store=foo` | Initialize and mount the new sub store *foo*
+| `gopass recipients add`| `gopass recipients add --store=foo GPGxID` | Add the new recipient *GPGxID* to the store *foo*
+| `gopass recipients remove` | `gopass recipients remove --store=foo GPGxID` | Remove the existing recipients *GPGxID* from the store *foo*
 
 ### Directly edit structured secrets aka. YAML support
 
@@ -311,7 +330,20 @@ $ gopass recipients
 gopass
 ├── 0xB1C7DF661ABB2C1A - Someone <someone@example.com>
 └── 0xB5B44266A3683834 - Gopher <gopher@golang.org>
+
+$ gopass recipients remove 0xB5B44266A3683834
+
+$ gopass recipients
+gopass
+└── 0xB1C7DF661ABB2C1A - Someone <someone@example.com>
 ```
+
+Running `gopass recipients` will also try to load and save any missing GPG keys
+from and to the store.
+
+The commands manipulating recipients, i.e. `gopass recipients add` and
+`gopass recpients remove` accept a `--store` flag that expects the
+*name of a mount point* to operate on this mounted sub store.
 
 ### Debugging
 

--- a/action/audit.go
+++ b/action/audit.go
@@ -91,9 +91,9 @@ func (s *Action) Audit(c *cli.Context) error {
 		if len(secrets) > 1 {
 			foundDuplicates = true
 
-			fmt.Printf(color.CyanString("Detected a shared secret for:\n"))
+			fmt.Println(color.CyanString("Detected a shared secret for:"))
 			for _, secret := range secrets {
-				fmt.Printf(color.CyanString("\t- %s\n", secret))
+				fmt.Println(color.CyanString("\t- %s", secret))
 			}
 		}
 	}
@@ -136,9 +136,9 @@ func printAuditResults(m map[string][]string, format string, color func(format s
 
 	for msg, secrets := range m {
 		b = true
-		fmt.Printf(color(format, msg))
+		fmt.Print(color(format, msg))
 		for _, secret := range secrets {
-			fmt.Printf(color("\t- %s\n", secret))
+			fmt.Print(color("\t- %s\n", secret))
 		}
 	}
 

--- a/action/init.go
+++ b/action/init.go
@@ -18,8 +18,8 @@ func (s *Action) Initialized(*cli.Context) error {
 
 // Init a new password store with a first gpg id
 func (s *Action) Init(c *cli.Context) error {
-	path := c.String("store")
-	alias := c.String("alias")
+	path := c.String("path")
+	alias := c.String("store")
 	nogit := c.Bool("nogit")
 
 	return s.init(alias, path, nogit, c.Args()...)

--- a/main.go
+++ b/main.go
@@ -354,11 +354,11 @@ func main() {
 			Action: action.Init,
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "store, s",
-					Usage: "Set the sub store to operate on",
+					Name:  "path, p",
+					Usage: "Set the sub store path to operate on",
 				},
 				cli.StringFlag{
-					Name:  "alias, a",
+					Name:  "store, s",
 					Usage: "Set the name of the sub store",
 				},
 				cli.BoolFlag{

--- a/store/root/mount.go
+++ b/store/root/mount.go
@@ -46,7 +46,7 @@ func (r *Store) addMount(alias, path string, keys ...string) error {
 
 	if !s.Initialized() {
 		if len(keys) < 1 {
-			return fmt.Errorf("password store %s is not initialized. Try gopass init --alias %s --store %s", alias, alias, path)
+			return fmt.Errorf("password store %s is not initialized. Try gopass init --store %s --path %s", alias, alias, path)
 		}
 		if err := s.Init(path, keys...); err != nil {
 			return err

--- a/store/sub/store.go
+++ b/store/sub/store.go
@@ -92,7 +92,7 @@ func (s *Store) Initialized() bool {
 func (s *Store) Init(path string, ids ...string) error {
 	if s.Initialized() {
 		return fmt.Errorf(`Found already initialized store at %s.
-You can add secondary stores with gopass init --store <path to secondary store> --alias <mount name>`, path)
+You can add secondary stores with gopass init --path <path to secondary store> --store <mount name>`, path)
 	}
 
 	// initialize recipient list

--- a/store/sub/store_test.go
+++ b/store/sub/store_test.go
@@ -51,10 +51,7 @@ func TestList(t *testing.T) {
 		{
 			name: "Single entry",
 			prep: func(s *Store) error {
-				if err := s.Set("foo", []byte("bar"), "test"); err != nil {
-					return err
-				}
-				return nil
+				return s.Set("foo", []byte("bar"), "test")
 			},
 			out: []string{"foo"},
 		},

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -20,17 +20,17 @@ func TestInit(t *testing.T) {
 	out, err = ts.run("init " + keyID)
 	assert.NoError(t, err)
 	assert.Contains(t, out, "Please enter a user name for password store git config [John Doe]:")
-	
+
 	ts = newTester(t)
 	defer ts.teardown()
 
 	ts.initStore()
 	// try to init again
-	out, err = ts.run("init "  + keyID)
+	out, err = ts.run("init " + keyID)
 	assert.Error(t, err)
 	for _, o := range []string{
 		"Error: Found already initialized store at /tmp/gopass-",
-		"You can add secondary stores with gopass init --store <path to secondary store> --alias <mount name>",
+		"You can add secondary stores with gopass init --path <path to secondary store> --store <mount name>",
 	} {
 		assert.Contains(t, out, o)
 	}

--- a/tests/mount_test.go
+++ b/tests/mount_test.go
@@ -22,7 +22,7 @@ func TestSingleMount(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "moar", out)
 
-	out, err = ts.run("init --alias mnt/m1 --store " + ts.storeDir("m1") + " --nogit " + keyID)
+	out, err = ts.run("init --store mnt/m1 --path " + ts.storeDir("m1") + " --nogit " + keyID)
 	t.Logf("Output: %s", out)
 	assert.NoError(t, err)
 
@@ -62,7 +62,7 @@ func TestMultiMount(t *testing.T) {
 	ts.initSecrets("")
 
 	// mount m1
-	out, err := ts.run("init --alias mnt/m1 --store " + ts.storeDir("m1") + " --nogit " + keyID)
+	out, err := ts.run("init --store mnt/m1 --path " + ts.storeDir("m1") + " --nogit " + keyID)
 	t.Logf("Output: %s", out)
 	assert.NoError(t, err)
 
@@ -90,7 +90,7 @@ func TestMultiMount(t *testing.T) {
 	assert.Equal(t, strings.TrimSpace(list), out)
 
 	// mount m2
-	out, err = ts.run("init --alias mnt/m2 --store " + ts.storeDir("m2") + " --nogit " + keyID)
+	out, err = ts.run("init --store mnt/m2 --path " + ts.storeDir("m2") + " --nogit " + keyID)
 	t.Logf("Output: %s", out)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
This commit improves documentation wrt. sub-stores, fixes some
tests and better aligns the gopass init parameters with the
rest of the commands.

Fixes #200