### PR TITLE
Introduce a jobs flag for the audit command

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,6 +113,13 @@ func main() {
 			Description: "To check passwords for common flaws (e.g. too short or from a dictionary)",
 			Before:      action.Initialized,
 			Action:      action.Audit,
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "jobs, j",
+					Usage: "The number of jobs to run concurrently when auditing",
+					Value: 1,
+				},
+			},
 		},
 		{
 			Name:    "binary",


### PR DESCRIPTION
Set -j=2 or more to run concurrently.
1 and no concurrency is the default.
