### PR TITLE
Fix IFS in bash completion, reduce environment pollution.

### DIFF
--- a/action/completion.go
+++ b/action/completion.go
@@ -33,21 +33,17 @@ func (s *Action) Complete(*cli.Context) {
 
 // CompletionBash returns a bash script used for auto completion
 func (s *Action) CompletionBash(c *cli.Context) error {
-	out := `#!/bin/bash
-
-PROG=gopass
-
-_cli_bash_autocomplete() {
+	out := `_gopass_bash_autocomplete() {
      local cur opts base
      COMPREPLY=()
-     local IFS=$'\n'
      cur="${COMP_WORDS[COMP_CWORD]}"
      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+     local IFS=$'\n'
      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
      return 0
  }
 
-complete -F _cli_bash_autocomplete $PROG
+complete -F _gopass_bash_autocomplete gopass
 `
 	fmt.Println(out)
 

--- a/tests/completion_test.go
+++ b/tests/completion_test.go
@@ -15,21 +15,17 @@ func TestCompletion(t *testing.T) {
 	assert.Contains(t, out, "Source for auto completion in bash")
 	assert.Contains(t, out, "Source for auto completion in zsh")
 
-	bash := `#!/bin/bash
-
-PROG=gopass
-
-_cli_bash_autocomplete() {
+	bash := `_gopass_bash_autocomplete() {
      local cur opts base
      COMPREPLY=()
-     local IFS=$'\n'
      cur="${COMP_WORDS[COMP_CWORD]}"
      opts=$( ${COMP_WORDS[@]:0:$COMP_CWORD} --generate-bash-completion )
+     local IFS=$'\n'
      COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
      return 0
  }
 
-complete -F _cli_bash_autocomplete $PROG`
+complete -F _gopass_bash_autocomplete gopass`
 
 	out, err = ts.run("completion bash")
 	assert.NoError(t, err)


### PR DESCRIPTION
This fixes issue #262. The bug was a regression introduced in d78b249 and was caused by IFS being set too early. I also took the liberty of tunig the completion code a bit:

* The code will always be sourced in the running shell, so no need for the hasbang
* The completion name was pretty generic; changed it to be more specific (and less prone to cause collissions)
* Remove the `PROG` variable