### PR TITLE
Check newly inserted secrets with crunchy

### DIFF
--- a/action/insert.go
+++ b/action/insert.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/fatih/color"
+	"github.com/muesli/crunchy"
 	"github.com/urfave/cli"
 )
 
@@ -90,6 +92,11 @@ func (s *Action) Insert(c *cli.Context) error {
 		return fmt.Errorf("failed to ask for password: %v", err)
 	}
 	content = []byte(pw)
+
+	validator := crunchy.NewValidator()
+	if err := validator.Check(pw); err != nil {
+		fmt.Println(color.CyanString(fmt.Sprintf("Warning: %s", err)))
+	}
 
 	return s.Store.SetConfirm(name, content, "Inserted user supplied password", confirm)
 }


### PR DESCRIPTION
I decided to keep the dupe check out of this quick password audit, so inserting new secrets remains as fast as possible.