### PR TITLE
Check edited secrets with crunchy

### DIFF
--- a/action/audit.go
+++ b/action/audit.go
@@ -143,3 +143,10 @@ func printAuditResults(m map[string][]string, format string, color func(format s
 
 	return b
 }
+
+func printAuditResult(pw string) {
+	validator := crunchy.NewValidator()
+	if err := validator.Check(pw); err != nil {
+		fmt.Println(color.CyanString(fmt.Sprintf("Warning: %s", err)))
+	}
+}

--- a/action/edit.go
+++ b/action/edit.go
@@ -51,6 +51,8 @@ func (s *Action) Edit(c *cli.Context) error {
 		return nil
 	}
 
+	printAuditResult(string(nContent))
+
 	return s.Store.SetConfirm(name, nContent, fmt.Sprintf("Edited with %s", os.Getenv("EDITOR")), s.confirmRecipients)
 }
 

--- a/action/insert.go
+++ b/action/insert.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/fatih/color"
-	"github.com/muesli/crunchy"
 	"github.com/urfave/cli"
 )
 
@@ -91,12 +89,9 @@ func (s *Action) Insert(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to ask for password: %v", err)
 	}
+
+	printAuditResult(pw)
+
 	content = []byte(pw)
-
-	validator := crunchy.NewValidator()
-	if err := validator.Check(pw); err != nil {
-		fmt.Println(color.CyanString(fmt.Sprintf("Warning: %s", err)))
-	}
-
 	return s.Store.SetConfirm(name, content, "Inserted user supplied password", confirm)
 }


### PR DESCRIPTION
Added a generic single-password audit helper to audit.go, which gets used for checking newly inserted or edited passwords.