### PR TITLE
Improve error handling and propagation

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -28,6 +28,7 @@ type Action struct {
 	Store   *root.Store
 	gpg     gpger
 	isTerm  bool
+	debug   bool
 	version semver.Version
 }
 
@@ -60,6 +61,7 @@ func New(sv semver.Version) *Action {
 	// debug flag
 	if gdb := os.Getenv("GOPASS_DEBUG"); gdb == "true" {
 		cfg.Debug = true
+		act.debug = true
 	}
 
 	// need this override for our integration tests

--- a/action/audit.go
+++ b/action/audit.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/fatih/color"
 	"github.com/muesli/crunchy"
@@ -28,7 +27,7 @@ type auditedSecret struct {
 func (s *Action) Audit(c *cli.Context) error {
 	t, err := s.Store.Tree()
 	if err != nil {
-		return err
+		return s.exitError(ExitList, err, "failed to get store tree: %s", err)
 	}
 	list := t.List(0)
 
@@ -107,7 +106,7 @@ func (s *Action) Audit(c *cli.Context) error {
 	foundErrors := printAuditResults(errors, "%s:\n", color.RedString)
 
 	if foundWeakPasswords || foundDuplicates || foundErrors {
-		os.Exit(1)
+		return s.exitError(ExitAudit, nil, "found weak passwords or duplicates")
 	}
 
 	return nil

--- a/action/binary.go
+++ b/action/binary.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/fsutil"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -24,7 +25,7 @@ const (
 func (s *Action) BinaryCat(c *cli.Context) error {
 	name := c.Args().First()
 	if name == "" {
-		return fmt.Errorf("need a name")
+		return s.exitError(ExitNoName, nil, "need a name")
 	}
 	if !strings.HasSuffix(name, BinarySuffix) {
 		name += BinarySuffix
@@ -33,14 +34,15 @@ func (s *Action) BinaryCat(c *cli.Context) error {
 	// handle pipe to stdin
 	info, err := os.Stdin.Stat()
 	if err != nil {
-		return fmt.Errorf("Failed to stat stdin: %s", err)
+		return s.exitError(ExitIO, err, "failed to stat stdin: %s", err)
 	}
+
 	// if content is piped to stdin, read and save it
 	if info.Mode()&os.ModeCharDevice == 0 {
 		content := &bytes.Buffer{}
 
 		if written, err := io.Copy(content, os.Stdin); err != nil {
-			return fmt.Errorf("Failed to copy after %d bytes: %s", written, err)
+			return s.exitError(ExitIO, err, "Failed to copy after %d bytes: %s", written, err)
 		}
 
 		return s.Store.Set(name, []byte(base64.StdEncoding.EncodeToString(content.Bytes())), "Read secret from STDIN")
@@ -48,7 +50,7 @@ func (s *Action) BinaryCat(c *cli.Context) error {
 
 	buf, err := s.binaryGet(name)
 	if err != nil {
-		return err
+		return s.exitError(ExitDecrypt, err, "failed to read secret: %s", err)
 	}
 	color.Yellow(string(buf))
 	return nil
@@ -58,18 +60,21 @@ func (s *Action) BinaryCat(c *cli.Context) error {
 func (s *Action) BinarySum(c *cli.Context) error {
 	name := c.Args().First()
 	if name == "" {
-		return fmt.Errorf("Usage: gopass binary sha256 name")
+		return s.exitError(ExitUsage, nil, "Usage: %s binary sha256 name", s.Name)
 	}
 	if !strings.HasSuffix(name, BinarySuffix) {
 		name += BinarySuffix
 	}
+
 	buf, err := s.binaryGet(name)
 	if err != nil {
-		return err
+		return s.exitError(ExitDecrypt, err, "failed to read secret: %s", err)
 	}
+
 	h := sha256.New()
 	_, _ = h.Write(buf)
-	color.Yellow("%x", h.Sum(nil))
+	fmt.Println(color.YellowString("%x", h.Sum(nil)))
+
 	return nil
 }
 
@@ -79,7 +84,10 @@ func (s *Action) BinaryCopy(c *cli.Context) error {
 	from := c.Args().Get(0)
 	to := c.Args().Get(1)
 
-	return s.binaryCopy(from, to, false)
+	if err := s.binaryCopy(from, to, false); err != nil {
+		return s.exitError(ExitUnknown, err, "%s", err)
+	}
+	return nil
 }
 
 // BinaryMove works like BinaryCopy but will remove (shred/wipe) the source
@@ -89,7 +97,10 @@ func (s *Action) BinaryMove(c *cli.Context) error {
 	from := c.Args().Get(0)
 	to := c.Args().Get(1)
 
-	return s.binaryCopy(from, to, true)
+	if err := s.binaryCopy(from, to, true); err != nil {
+		return s.exitError(ExitUnknown, err, "%s", err)
+	}
+	return nil
 }
 
 // binaryCopy implements the control flow for copy and move. We support two
@@ -104,15 +115,15 @@ func (s *Action) binaryCopy(from, to string, deleteSource bool) error {
 		if deleteSource {
 			op = "move"
 		}
-		return fmt.Errorf("Usage: gopass binary %s from to", op)
+		return errors.Errorf("Usage: %s binary %s from to", s.Name, op)
 	}
 	switch {
 	case fsutil.IsFile(from) && fsutil.IsFile(to):
 		// copying from on file to another file is not supported
-		return fmt.Errorf("ambiquity detected. Only from or to can a file")
+		return errors.New("ambiquity detected. Only from or to can be a file")
 	case s.Store.Exists(from) && s.Store.Exists(to):
 		// copying from one secret to another secret is not supported
-		return fmt.Errorf("ambiquity detected. Either from or to must be a file")
+		return errors.New("ambiquity detected. Either from or to must be a file")
 	case fsutil.IsFile(from) && !fsutil.IsFile(to):
 		// if the source is a file the destination must no to avoid ambiquities
 		// if necessary this can be resolved by using a absolute path for the file
@@ -123,16 +134,20 @@ func (s *Action) binaryCopy(from, to string, deleteSource bool) error {
 		// copy from FS to store
 		buf, err := ioutil.ReadFile(from)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to read file from '%s'", from)
 		}
 		if err := s.Store.Set(to, []byte(base64.StdEncoding.EncodeToString(buf)), fmt.Sprintf("Copied data from %s to %s", from, to)); err != nil {
-			return err
+			return errors.Wrapf(err, "failed to save buffer to store")
 		}
 		if deleteSource {
+			// it's important that we return if the validation fails, because
+			// in that case we don't want to shred our (only) copy of this data!
 			if err := s.binaryValidate(buf, to); err != nil {
-				return err
+				return errors.Wrapf(err, "failed to validate written data")
 			}
-			return fsutil.Shred(from, 8)
+			if err := fsutil.Shred(from, 8); err != nil {
+				return errors.Wrapf(err, "failed to shred data")
+			}
 		}
 		return nil
 	case !fsutil.IsFile(from):
@@ -144,20 +159,24 @@ func (s *Action) binaryCopy(from, to string, deleteSource bool) error {
 		// copy from store to FS
 		buf, err := s.binaryGet(from)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to read data from '%s'", from)
 		}
 		if err := ioutil.WriteFile(to, buf, 0600); err != nil {
-			return err
+			return errors.Wrapf(err, "failed to write data to '%s'", to)
 		}
 		if deleteSource {
+			// as before: if validation of the written data fails, we MUST NOT
+			// delete the (only) source
 			if err := s.binaryValidate(buf, from); err != nil {
-				return err
+				return errors.Wrapf(err, "failed to validate the written data")
 			}
-			return s.Store.Delete(from)
+			if err := s.Store.Delete(from); err != nil {
+				return errors.Wrapf(err, "failed to delete '%s' from the store", from)
+			}
 		}
 		return nil
 	default:
-		return fmt.Errorf("ambiquity detected. Unhandled case. Please report a bug")
+		return errors.Errorf("ambiquity detected. Unhandled case. Please report a bug")
 	}
 }
 
@@ -171,13 +190,13 @@ func (s *Action) binaryValidate(buf []byte, name string) error {
 	var err error
 	buf, err = s.binaryGet(name)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to read '%s' from the store", name)
 	}
 	_, _ = h.Write(buf)
 	storeSum := fmt.Sprintf("%x", h.Sum(nil))
 
 	if fileSum != storeSum {
-		return fmt.Errorf("Hashsum mismatch (file: %s, store: %s)", fileSum, storeSum)
+		return errors.Errorf("Hashsum mismatch (file: %s, store: %s)", fileSum, storeSum)
 	}
 	return nil
 }
@@ -185,11 +204,11 @@ func (s *Action) binaryValidate(buf []byte, name string) error {
 func (s *Action) binaryGet(name string) ([]byte, error) {
 	buf, err := s.Store.Get(name)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to read '%s' from the store", name)
 	}
 	buf, err = base64.StdEncoding.DecodeString(string(buf))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "failed to encode to base64")
 	}
 	return buf, nil
 }

--- a/action/copy.go
+++ b/action/copy.go
@@ -11,24 +11,24 @@ func (s *Action) Copy(c *cli.Context) error {
 	force := c.Bool("force")
 
 	if len(c.Args()) != 2 {
-		return fmt.Errorf("Usage: gopass cp old-path new-path")
+		return s.exitError(ExitUsage, nil, "Usage: %s cp old-path new-path", s.Name)
 	}
 
 	from := c.Args()[0]
 	to := c.Args()[1]
 
 	if !s.Store.Exists(from) {
-		return fmt.Errorf("%s doesn't exists", from)
+		return s.exitError(ExitNotFound, nil, "%s does not exist", from)
 	}
 
 	if !force {
 		if s.Store.Exists(to) && !s.askForConfirmation(fmt.Sprintf("%s already exists. Overwrite it?", to)) {
-			return fmt.Errorf("not overwriting your current secret")
+			return s.exitError(ExitAborted, nil, "not overwriting your current secret")
 		}
 	}
 
 	if err := s.Store.Copy(from, to); err != nil {
-		return err
+		return s.exitError(ExitIO, err, "failed to copy from '%s' to '%s'", from, to)
 	}
 
 	return nil

--- a/action/delete.go
+++ b/action/delete.go
@@ -3,6 +3,7 @@ package action
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -13,8 +14,9 @@ func (s *Action) Delete(c *cli.Context) error {
 
 	name := c.Args().First()
 	if name == "" {
-		return fmt.Errorf("provide a secret name")
+		return s.exitError(ExitUsage, nil, "Usage: %s rm name", s.Name)
 	}
+
 	key := c.Args().Get(1)
 
 	if !force { // don't check if it's force anyway
@@ -28,17 +30,26 @@ func (s *Action) Delete(c *cli.Context) error {
 	}
 
 	if recursive {
-		return s.Store.Prune(name)
+		if err := s.Store.Prune(name); err != nil {
+			return s.exitError(ExitUnknown, err, "failed to prune '%s': %s", name, err)
+		}
+		return nil
 	}
 
 	if s.Store.IsDir(name) {
-		return fmt.Errorf("Cannot remove '%s': Is a directory. Use 'gopass rm -r %s' to delete", name, name)
+		return errors.Errorf("Cannot remove '%s': Is a directory. Use 'gopass rm -r %s' to delete", name, name)
 	}
 
 	// deletes a single key from a YAML doc
 	if key != "" {
-		return s.Store.DeleteKey(name, key)
+		if err := s.Store.DeleteKey(name, key); err != nil {
+			return s.exitError(ExitIO, err, "Can not delete key '%s' from '%s': %s", key, name, err)
+		}
+		return nil
 	}
 
-	return s.Store.Delete(name)
+	if err := s.Store.Delete(name); err != nil {
+		return s.exitError(ExitIO, err, "Can not delete '%s': %s", name, err)
+	}
+	return nil
 }

--- a/action/errors.go
+++ b/action/errors.go
@@ -1,0 +1,58 @@
+package action
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/urfave/cli"
+)
+
+const (
+	// ExitOK means no error (status code 0)
+	ExitOK = iota
+	// ExitUnknown is used if we can't determine the exact exit cause
+	ExitUnknown
+	// ExitUsage is used if there was some kind of invocation error
+	ExitUsage
+	// ExitAborted is used if the user willingly aborted an action
+	ExitAborted
+	// ExitUnsupported is used if an operation is not supported by gopass
+	ExitUnsupported
+	// ExitAlreadyInitialized is used if someone is trying to initialize
+	// an already initialized store
+	ExitAlreadyInitialized
+	// ExitNotInitialized is used if someone is trying to use an unitialized
+	// store
+	ExitNotInitialized
+	// ExitGit is used if any git errors are encountered
+	ExitGit
+	// ExitMount is used if a substore mount operation fails
+	ExitMount
+	// ExitNoName is used when no name was provided for a named entry
+	ExitNoName
+	// ExitNotFound is used if a requested secret is not found
+	ExitNotFound
+	// ExitDecrypt is used when reading/decrypting a secret failed
+	ExitDecrypt
+	// ExitEncrypt is used when writing/encrypting of a secret fails
+	ExitEncrypt
+	// ExitList is used when listing the store content fails
+	ExitList
+	// ExitAudit is used when audit report possible issues
+	ExitAudit
+	// ExitFsck is used when the integrity check fails
+	ExitFsck
+	// ExitConfig is used when config errors occur
+	ExitConfig
+	// ExitRecipients is used when a recipient operation fails
+	ExitRecipients
+	// ExitIO is used for misc. I/O errors
+	ExitIO
+)
+
+func (s *Action) exitError(exitCode int, err error, format string, args ...interface{}) error {
+	if s.debug && err != nil {
+		fmt.Println(color.RedString("Stacktrace: %+v", err))
+	}
+	return cli.NewExitError(fmt.Sprintf(format, args...), exitCode)
+}

--- a/action/find.go
+++ b/action/find.go
@@ -12,13 +12,14 @@ import (
 // Find a string in the secret file's name
 func (s *Action) Find(c *cli.Context) error {
 	if !c.Args().Present() {
-		return fmt.Errorf("Usage: gopass find arg")
+		return s.exitError(ExitUsage, nil, "Usage: %s find arg", s.Name)
 	}
 
 	l, err := s.Store.List(0)
 	if err != nil {
-		return err
+		return s.exitError(ExitList, err, "failed to list store: %s", err)
 	}
+
 	needle := strings.ToLower(c.Args().First())
 	choices := make([]string, 0, 10)
 	for _, value := range l {
@@ -50,6 +51,6 @@ func (s *Action) Find(c *cli.Context) error {
 	case "show":
 		return s.show(c, choices[sel], "", false, false, false)
 	default:
-		return fmt.Errorf("User aborted")
+		return s.exitError(ExitAborted, nil, "user aborted")
 	}
 }

--- a/action/fsck.go
+++ b/action/fsck.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -19,15 +20,19 @@ func (s *Action) Fsck(c *cli.Context) error {
 	// make sure config is in the right place
 	// we may have loaded it from one of the fallback locations
 	if err := s.Store.Config().Save(); err != nil {
-		return err
+		return s.exitError(ExitConfig, err, "failed to save config: %s", err)
 	}
 	// clean up any previous config locations
 	oldCfg := filepath.Join(os.Getenv("HOME"), ".gopass.yml")
 	if fsutil.IsFile(oldCfg) {
 		if err := os.Remove(oldCfg); err != nil {
-			color.Red("Failed to remove old gopass config %s: %s", oldCfg, err)
+			fmt.Println(color.RedString("Failed to remove old gopass config %s: %s", oldCfg, err))
 		}
 	}
+
 	_, err := s.Store.Fsck("", check, force)
-	return err
+	if err != nil {
+		return s.exitError(ExitFsck, err, "fsck found errors")
+	}
+	return nil
 }

--- a/action/grep.go
+++ b/action/grep.go
@@ -11,20 +11,20 @@ import (
 // Grep searches a string inside the content of all files
 func (s *Action) Grep(c *cli.Context) error {
 	if !c.Args().Present() {
-		return fmt.Errorf("Usage: gopass grep arg")
+		return s.exitError(ExitUsage, nil, "Usage: %s grep arg", s.Name)
 	}
 
 	search := c.Args().First()
 
 	l, err := s.Store.List(0)
 	if err != nil {
-		return err
+		return s.exitError(ExitList, err, "failed to list store: %s", err)
 	}
 
 	for _, v := range l {
 		content, err := s.Store.Get(v)
 		if err != nil {
-			fmt.Printf("failed to decrypt %s: %v", v, err)
+			fmt.Println(color.RedString("failed to decrypt %s: %v", v, err))
 			continue
 		}
 

--- a/action/init.go
+++ b/action/init.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
+	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
 
@@ -11,7 +12,7 @@ import (
 // prepared.
 func (s *Action) Initialized(*cli.Context) error {
 	if !s.Store.Initialized() {
-		return fmt.Errorf("password-store is not initialized. Try '%s init'", s.Name)
+		return s.exitError(ExitNotInitialized, nil, "password-store is not initialized. Try '%s init'", s.Name)
 	}
 	return nil
 }
@@ -22,7 +23,10 @@ func (s *Action) Init(c *cli.Context) error {
 	alias := c.String("store")
 	nogit := c.Bool("nogit")
 
-	return s.init(alias, path, nogit, c.Args()...)
+	if err := s.init(alias, path, nogit, c.Args()...); err != nil {
+		return s.exitError(ExitUnknown, err, "failed to initialized store: %s", err)
+	}
+	return nil
 }
 
 func (s *Action) init(alias, path string, nogit bool, keys ...string) error {
@@ -33,18 +37,18 @@ func (s *Action) init(alias, path string, nogit bool, keys ...string) error {
 	if len(keys) < 1 {
 		nk, err := s.askForPrivateKey(color.CyanString("Please select a private key for encryption:"))
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to read user input")
 		}
 		keys = []string{nk}
 	}
 
 	if err := s.Store.Init(alias, path, keys...); err != nil {
-		return err
+		return errors.Wrapf(err, "failed to init store '%s' at '%s'", alias, path)
 	}
 
 	if alias != "" && path != "" {
 		if err := s.Store.AddMount(alias, path); err != nil {
-			return err
+			return errors.Wrapf(err, "failed to add mount '%s'", alias)
 		}
 	}
 
@@ -54,7 +58,10 @@ func (s *Action) init(alias, path string, nogit bool, keys ...string) error {
 			sk = keys[0]
 		}
 		if err := s.gitInit(alias, sk); err != nil {
-			color.Yellow("Failed to init git: %s", err)
+			if s.debug {
+				fmt.Println(color.RedString("Stacktrace: %+v\n", err))
+			}
+			fmt.Println(color.RedString("Failed to init git: %s", err))
 		}
 	}
 
@@ -64,13 +71,13 @@ func (s *Action) init(alias, path string, nogit bool, keys ...string) error {
 		if kl, err := s.gpg.FindPublicKeys(recipient); err == nil && len(kl) > 0 {
 			r = kl[0].OneLine()
 		}
-		color.Yellow("  " + r)
+		fmt.Println(color.YellowString("  " + r))
 	}
 	fmt.Println("")
 
 	// write config
 	if err := s.Store.Config().Save(); err != nil {
-		color.Red(fmt.Sprintf("Failed to write config: %s", err))
+		return s.exitError(ExitConfig, err, "failed to write config: %s", err)
 	}
 
 	return nil

--- a/action/move.go
+++ b/action/move.go
@@ -11,7 +11,7 @@ func (s *Action) Move(c *cli.Context) error {
 	force := c.Bool("force")
 
 	if len(c.Args()) != 2 {
-		return fmt.Errorf("Usage: gopass mv old-path new-path")
+		return s.exitError(ExitUsage, nil, "Usage: %s mv old-path new-path", s.Name)
 	}
 
 	from := c.Args()[0]
@@ -19,12 +19,12 @@ func (s *Action) Move(c *cli.Context) error {
 
 	if !force {
 		if s.Store.Exists(to) && !s.askForConfirmation(fmt.Sprintf("%s already exists. Overwrite it?", to)) {
-			return fmt.Errorf("not overwriting your current secret")
+			return s.exitError(ExitAborted, nil, "not overwriting your current secret")
 		}
 	}
 
 	if err := s.Store.Move(from, to); err != nil {
-		return err
+		return s.exitError(ExitUnknown, err, "%s", err)
 	}
 
 	return nil

--- a/action/recipients.go
+++ b/action/recipients.go
@@ -32,13 +32,16 @@ func (s *Action) RecipientsPrint(c *cli.Context) error {
 	if err := s.Store.ImportMissingPublicKeys(); err != nil {
 		fmt.Println(color.RedString("Failed to import missing public keys: %s", err))
 	}
+
 	if err := s.Store.SaveRecipients(); err != nil {
 		fmt.Println(color.RedString("Failed to export missing public keys: %s", err))
 	}
+
 	tree, err := s.Store.RecipientsTree(true)
 	if err != nil {
-		return err
+		return s.exitError(ExitList, err, "failed to list recipients: %s", err)
 	}
+
 	fmt.Println(tree.Format(0))
 	return nil
 }
@@ -80,14 +83,15 @@ func (s *Action) RecipientsAdd(c *cli.Context) error {
 		}
 
 		if err := s.Store.AddRecipient(store, keys[0].Fingerprint); err != nil {
-			return err
+			return s.exitError(ExitRecipients, err, "failed to add recipient '%s': %s", r, err)
 		}
 		added++
 	}
 	if added < 1 {
-		return fmt.Errorf("no key added")
+		return s.exitError(ExitUnknown, nil, "no key added")
 	}
-	fmt.Printf("Added %d recipients\n", added)
+
+	fmt.Println(color.GreenString("Added %d recipients\n", added))
 	return nil
 }
 
@@ -105,11 +109,12 @@ func (s *Action) RecipientsRemove(c *cli.Context) error {
 			}
 		}
 		if err := s.Store.RemoveRecipient(store, strings.TrimPrefix(r, "0x")); err != nil {
-			return err
+			return s.exitError(ExitRecipients, err, "failed to remove recipient '%s': %s", r, err)
 		}
 		fmt.Printf(removalWarning, r)
 		removed++
 	}
+
 	fmt.Printf("Removed %d recipients\n", removed)
 	return nil
 }

--- a/action/unclip.go
+++ b/action/unclip.go
@@ -19,7 +19,7 @@ func (s *Action) Unclip(c *cli.Context) error {
 
 	cur, err := clipboard.ReadAll()
 	if err != nil {
-		return err
+		return s.exitError(ExitIO, err, "failed to read clipboard: %s", err)
 	}
 
 	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(cur)))
@@ -28,7 +28,7 @@ func (s *Action) Unclip(c *cli.Context) error {
 		return nil
 	}
 	if err := clipboard.WriteAll(""); err != nil {
-		return err
+		return s.exitError(ExitIO, err, "failed to write clipboard: %s", err)
 	}
 
 	return nil

--- a/fsutil/tempdir.go
+++ b/fsutil/tempdir.go
@@ -1,11 +1,12 @@
 package fsutil
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
 
 type tempfile struct {
@@ -42,7 +43,7 @@ func TempFile(prefix string) (TempFiler, error) {
 	fn := filepath.Join(tf.dir, "tempfile")
 	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0600)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open file %s: %s", fn, err)
+		return nil, errors.Errorf("Failed to open file %s: %s", fn, err)
 	}
 	tf.fh = fh
 
@@ -58,7 +59,7 @@ func (t *tempfile) Name() string {
 
 func (t *tempfile) Write(p []byte) (int, error) {
 	if t.fh == nil {
-		return 0, fmt.Errorf("not initialized")
+		return 0, errors.Errorf("not initialized")
 	}
 	return t.fh.Write(p)
 }
@@ -73,7 +74,7 @@ func (t *tempfile) Close() error {
 func (t *tempfile) Remove() error {
 	_ = t.Close()
 	if err := t.unmount(); err != nil {
-		return fmt.Errorf("Failed to unmount %s from %s: %s", t.dev, t.dir, err)
+		return errors.Errorf("Failed to unmount %s from %s: %s", t.dev, t.dir, err)
 	}
 	return os.RemoveAll(t.dir)
 }

--- a/gpg/key_list.go
+++ b/gpg/key_list.go
@@ -1,8 +1,9 @@
 package gpg
 
 import (
-	"fmt"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // KeyList is a searchable slice of Keys
@@ -65,5 +66,5 @@ func (kl KeyList) FindKey(id string) (Key, error) {
 			}
 		}
 	}
-	return Key{}, fmt.Errorf("No matching key found")
+	return Key{}, errors.Errorf("No matching key found")
 }

--- a/gpg/mock/gpg.go
+++ b/gpg/mock/gpg.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/gpg"
+	"github.com/pkg/errors"
 )
 
 // Mocker is a no-op GPG mock
@@ -45,7 +46,7 @@ func (m *Mocker) GetRecipients(string) ([]string, error) {
 // Encrypt writes the input to disk unaltered
 func (m *Mocker) Encrypt(path string, content []byte, recipients []string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return err
+		return errors.Wrapf(err, "failed to create dir '%s'", path)
 	}
 	return ioutil.WriteFile(path, content, 0600)
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ type errorWriter struct {
 }
 
 func (e errorWriter) Write(p []byte) (int, error) {
-	return e.out.Write([]byte("\n" + color.RedString("Error: "+string(p))))
+	return e.out.Write([]byte("\n" + color.RedString("Error: %s", p)))
 }
 
 func main() {
@@ -300,6 +300,10 @@ func main() {
 				cli.BoolFlag{
 					Name:  "force, f",
 					Usage: "Force to overwrite existing password",
+				},
+				cli.BoolFlag{
+					Name:  "edit, e",
+					Usage: "Open secret for editing after generating a password",
 				},
 				cli.BoolFlag{
 					Name:   "no-symbols, n",

--- a/qrcon/qrcon.go
+++ b/qrcon/qrcon.go
@@ -2,9 +2,9 @@ package qrcon
 
 import (
 	"bytes"
-	"fmt"
 	"image/color"
 
+	"github.com/pkg/errors"
 	"github.com/skip2/go-qrcode"
 )
 
@@ -31,7 +31,7 @@ func QRCode(content string) (string, error) {
 			} else if sameColor(col, q.BackgroundColor) {
 				_, _ = buf.WriteString(white)
 			} else {
-				return "", fmt.Errorf("Unexpected color at (%d,%d): %+v", x, y, col)
+				return "", errors.Errorf("Unexpected color at (%d,%d): %+v", x, y, col)
 			}
 		}
 		_, _ = buf.WriteString("\n")

--- a/store/err.go
+++ b/store/err.go
@@ -1,34 +1,34 @@
 package store
 
-import "fmt"
+import "github.com/pkg/errors"
 
 var (
 	// ErrExistsFailed is returend if we can't check for existence
-	ErrExistsFailed = fmt.Errorf("Failed to check for existence")
+	ErrExistsFailed = errors.Errorf("Failed to check for existence")
 	// ErrNotFound is returned if an entry was not found
-	ErrNotFound = fmt.Errorf("Entry is not in the password store")
+	ErrNotFound = errors.Errorf("Entry is not in the password store")
 	// ErrEncrypt is returned if we failed to encrypt an entry
-	ErrEncrypt = fmt.Errorf("Failed to encrypt")
+	ErrEncrypt = errors.Errorf("Failed to encrypt")
 	// ErrDecrypt is returned if we failed to decrypt and entry
-	ErrDecrypt = fmt.Errorf("Failed to decrypt")
+	ErrDecrypt = errors.Errorf("Failed to decrypt")
 	// ErrSneaky is returned if the user passes a possible malicious path to gopass
-	ErrSneaky = fmt.Errorf("you've attempted to pass a sneaky path to gopass. go home")
+	ErrSneaky = errors.Errorf("you've attempted to pass a sneaky path to gopass. go home")
 	// ErrGitInit is returned if git is already initialized
-	ErrGitInit = fmt.Errorf("git is already initialized")
+	ErrGitInit = errors.Errorf("git is already initialized")
 	// ErrGitNotInit is returned if git is not initialized
-	ErrGitNotInit = fmt.Errorf("git is not initialized")
+	ErrGitNotInit = errors.Errorf("git is not initialized")
 	// ErrGitNoRemote is returned if git has no origin remote
-	ErrGitNoRemote = fmt.Errorf("git has no remote origin")
+	ErrGitNoRemote = errors.Errorf("git has no remote origin")
 	// ErrGitNothingToCommit is returned if there are no staged changes
-	ErrGitNothingToCommit = fmt.Errorf("git has nothing to commit")
+	ErrGitNothingToCommit = errors.Errorf("git has nothing to commit")
 	// ErrNoBody is returned if a secret exists but has no content beyond a password
-	ErrNoBody = fmt.Errorf("no safe content to display, you can force display with show -f")
+	ErrNoBody = errors.Errorf("no safe content to display, you can force display with show -f")
 	// ErrNoPassword is returned is a secret exists but has no password, only a body
-	ErrNoPassword = fmt.Errorf("no password to display")
+	ErrNoPassword = errors.Errorf("no password to display")
 	// ErrYAMLNoMark is returned if a secret contains no valid YAML document marker
-	ErrYAMLNoMark = fmt.Errorf("no YAML document marker found")
+	ErrYAMLNoMark = errors.Errorf("no YAML document marker found")
 	// ErrYAMLNoKey is returned if a YAML document doesn't contain a key
-	ErrYAMLNoKey = fmt.Errorf("key not found in YAML document")
+	ErrYAMLNoKey = errors.Errorf("key not found in YAML document")
 	// ErrYAMLValueUnsupported is returned is the user tries to unmarshal an nested struct
-	ErrYAMLValueUnsupported = fmt.Errorf("can not unmarshal nested YAML value")
+	ErrYAMLValueUnsupported = errors.Errorf("can not unmarshal nested YAML value")
 )

--- a/store/root/git.go
+++ b/store/root/git.go
@@ -7,6 +7,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/store"
+	"github.com/pkg/errors"
 )
 
 // GitInit initializes the git repo
@@ -33,7 +34,7 @@ func (r *Store) Git(name string, recurse, force bool, args ...string) error {
 			fmt.Println(color.YellowString("[%s] Has no remote. Skipping", dispName))
 		} else {
 			if !force {
-				return err
+				return errors.Wrapf(err, "failed to run git %s on sub store %s", strings.Join(args, " "), dispName)
 			}
 			fmt.Println(color.RedString("[%s] Failed to run 'git %s'", dispName, strings.Join(args, " ")))
 		}
@@ -53,7 +54,7 @@ func (r *Store) Git(name string, recurse, force bool, args ...string) error {
 				continue
 			}
 			if !force {
-				return err
+				return errors.Wrapf(err, "failed to perform git %s on %s", strings.Join(args, " "), alias)
 			}
 			fmt.Println(color.RedString("[%s] Failed to run 'git %s'", alias, strings.Join(args, " ")))
 		}

--- a/store/root/recipients.go
+++ b/store/root/recipients.go
@@ -8,6 +8,7 @@ import (
 	"github.com/justwatchcom/gopass/store"
 	"github.com/justwatchcom/gopass/tree"
 	"github.com/justwatchcom/gopass/tree/simple"
+	"github.com/pkg/errors"
 )
 
 // ListRecipients lists all recipients for the given store
@@ -81,7 +82,7 @@ func (r *Store) RecipientsTree(pretty bool) (tree.Tree, error) {
 			continue
 		}
 		if err := root.AddMount(alias, substore.Path()); err != nil {
-			return nil, fmt.Errorf("failed to add mount: %s", err)
+			return nil, errors.Errorf("failed to add mount: %s", err)
 		}
 		for _, recp := range substore.Recipients() {
 			if err := r.addRecipient(alias+"/", root, recp, pretty); err != nil {

--- a/store/root/templates.go
+++ b/store/root/templates.go
@@ -8,6 +8,7 @@ import (
 	"github.com/justwatchcom/gopass/store"
 	"github.com/justwatchcom/gopass/tree"
 	"github.com/justwatchcom/gopass/tree/simple"
+	"github.com/pkg/errors"
 )
 
 // LookupTemplate will lookup and return a template
@@ -34,7 +35,7 @@ func (r *Store) TemplateTree() (tree.Tree, error) {
 			continue
 		}
 		if err := root.AddMount(alias, substore.Path()); err != nil {
-			return nil, fmt.Errorf("failed to add mount: %s", err)
+			return nil, errors.Errorf("failed to add mount: %s", err)
 		}
 		for _, t := range substore.ListTemplates(alias) {
 			if err := root.AddFile(t, "gopass/template"); err != nil {

--- a/store/sub/config.go
+++ b/store/sub/config.go
@@ -1,9 +1,8 @@
 package sub
 
 import (
-	"fmt"
-
 	"github.com/justwatchcom/gopass/config"
+	"github.com/pkg/errors"
 )
 
 // Config returns this sub stores config as a config struct
@@ -22,7 +21,7 @@ func (s *Store) Config() *config.Config {
 // UpdateConfig updates this sub-stores internal config
 func (s *Store) UpdateConfig(cfg *config.Config) error {
 	if cfg == nil {
-		return fmt.Errorf("invalid config")
+		return errors.Errorf("invalid config")
 	}
 	s.autoImport = cfg.AutoImport
 	s.autoSync = cfg.AutoSync

--- a/store/sub/fsck.go
+++ b/store/sub/fsck.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/fsutil"
 	"github.com/justwatchcom/gopass/gpg"
+	"github.com/pkg/errors"
 )
 
 // Fsck checks this stores integrity
@@ -83,7 +84,7 @@ func (s *Store) fsckCheckDir(prefix, fn string, check, force bool, askFunc func(
 	// check for empty folders
 	isEmpty, err := fsutil.IsEmptyDir(fn)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to check if '%s' is empty", fn)
 	}
 	if isEmpty {
 		fmt.Println(color.YellowString("[%s] Empty folder: %s", prefix, fn))
@@ -192,19 +193,19 @@ func fsckCheckRecipientsInSubkeys(key gpg.Key, recipients []string) error {
 			}
 		}
 	}
-	return fmt.Errorf("None of the Recipients matches a subkey")
+	return errors.Errorf("None of the Recipients matches a subkey")
 }
 
 func (s *Store) fsckCheckSelfDecrypt(fn string) error {
 	_, err := s.Get(s.filenameToName(fn))
-	return err
+	return errors.Wrapf(err, "failed to decode secret")
 }
 
 func (s *Store) fsckFixRecipients(fn string) error {
 	name := s.filenameToName(fn)
 	content, err := s.Get(s.filenameToName(fn))
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to decode secret")
 	}
 	return s.Set(name, content, "fsck fix recipients")
 }

--- a/store/sub/templates.go
+++ b/store/sub/templates.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/fsutil"
 	"github.com/justwatchcom/gopass/tree"
 	"github.com/justwatchcom/gopass/tree/simple"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -120,7 +121,7 @@ func (s *Store) SetTemplate(name string, content []byte) error {
 func (s *Store) RemoveTemplate(name string) error {
 	t := s.templatefile(name)
 	if !fsutil.IsFile(t) {
-		return fmt.Errorf("template not found")
+		return errors.Errorf("template not found")
 	}
 
 	return os.Remove(t)

--- a/store/sub/yaml.go
+++ b/store/sub/yaml.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/justwatchcom/gopass/store"
+	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -39,7 +40,7 @@ func (s *Store) GetKey(name, key string) ([]byte, error) {
 func (s *Store) SetKey(name, key, value string) error {
 	content, err := s.Get(name)
 	if err != nil && err != store.ErrNotFound {
-		return err
+		return errors.Wrapf(err, "failed to read secret '%s'", name)
 	}
 
 	parts := bytes.Split(content, []byte("---\n"))
@@ -47,7 +48,7 @@ func (s *Store) SetKey(name, key, value string) error {
 	d := make(map[string]interface{})
 	if len(parts) > 1 {
 		if err := yaml.Unmarshal(parts[1], &d); err != nil {
-			return err
+			return errors.Wrapf(err, "failed to decode YAML from secret '%s'", name)
 		}
 	}
 
@@ -55,7 +56,7 @@ func (s *Store) SetKey(name, key, value string) error {
 
 	buf, err := yaml.Marshal(d)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to encode YAML for secret '%s'", name)
 	}
 
 	return s.SetConfirm(name, append(parts[0], append([]byte("\n---\n"), buf...)...), fmt.Sprintf("Updated key in %s", name), nil)
@@ -65,7 +66,7 @@ func (s *Store) SetKey(name, key, value string) error {
 func (s *Store) DeleteKey(name, key string) error {
 	content, err := s.Get(name)
 	if err != nil && err != store.ErrNotFound {
-		return err
+		return errors.Wrapf(err, "failed to read secret '%s'", name)
 	}
 
 	parts := bytes.Split(content, []byte("---\n"))
@@ -73,7 +74,7 @@ func (s *Store) DeleteKey(name, key string) error {
 	d := make(map[string]interface{})
 	if len(parts) > 1 {
 		if err := yaml.Unmarshal(parts[1], &d); err != nil {
-			return err
+			return errors.Wrapf(err, "failed to decode YAML from secret '%s'", name)
 		}
 	}
 
@@ -81,7 +82,7 @@ func (s *Store) DeleteKey(name, key string) error {
 
 	buf, err := yaml.Marshal(d)
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "failed to encode YAML for secret '%s'", name)
 	}
 
 	return s.SetConfirm(name, append(parts[0], append([]byte("---\n"), buf...)...), fmt.Sprintf("Deleted key %s in %s", key, name), nil)

--- a/tests/binary_test.go
+++ b/tests/binary_test.go
@@ -20,7 +20,7 @@ func TestBinaryCopy(t *testing.T) {
 
 	out, err := ts.run("binary copy")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: gopass binary copy from to\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" binary copy from to\n", out)
 
 	fn := filepath.Join(ts.tempDir, "copy")
 	dat := []byte("foobar")
@@ -54,7 +54,7 @@ func TestBinaryMove(t *testing.T) {
 
 	out, err := ts.run("binary move")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: gopass binary move from to\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" binary move from to\n", out)
 
 	fn := filepath.Join(ts.tempDir, "move")
 	dat := []byte("foobar")
@@ -88,7 +88,7 @@ func TestBinaryShasum(t *testing.T) {
 
 	out, err := ts.run("binary sha256")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: gopass binary sha256 name\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" binary sha256 name\n", out)
 
 	fn := filepath.Join(ts.tempDir, "shasum")
 	dat := []byte("foobar")

--- a/tests/copy_test.go
+++ b/tests/copy_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,22 +18,22 @@ func TestCopy(t *testing.T) {
 
 	out, err := ts.run("copy")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: gopass cp old-path new-path\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" cp old-path new-path\n", out)
 
 	out, err = ts.run("copy foo")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: gopass cp old-path new-path\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" cp old-path new-path\n", out)
 
 	out, err = ts.run("copy foo bar")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: foo doesn't exists\n", out)
+	assert.Equal(t, "\nError: foo does not exist\n", out)
 
 	ts.initSecrets("")
 
-	//TODO: foo is a directory to be copied, which doesn't work
+	// TODO: foo is a directory to be copied, which doesn't work
 	out, err = ts.run("copy foo bar")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: foo doesn't exists\n", out)
+	assert.Equal(t, "\nError: foo does not exist\n", out)
 
 	out, err = ts.run("copy foo/bar foo/baz")
 	assert.NoError(t, err)

--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,11 +15,11 @@ func TestDelete(t *testing.T) {
 
 	out, err := ts.run("delete")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: provide a secret name\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" rm name\n", out)
 
 	out, err = ts.run("delete foobarbaz")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Entry is not in the password store\n", out)
+	assert.Equal(t, "\nError: Can not delete 'foobarbaz': Entry is not in the password store\n", out)
 
 	ts.initSecrets("")
 
@@ -30,6 +31,6 @@ func TestDelete(t *testing.T) {
 
 		out, err = ts.run("delete -f " + secret)
 		assert.Error(t, err)
-		assert.Equal(t, "\nError: Entry is not in the password store\n", out)
+		assert.Equal(t, "\nError: Can not delete '"+secret+"': Entry is not in the password store\n", out)
 	}
 }

--- a/tests/find_test.go
+++ b/tests/find_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ func TestFind(t *testing.T) {
 
 	out, err := ts.run("find")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: gopass find arg\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" find arg\n", out)
 
 	out, err = ts.run("config safecontent false")
 	assert.NoError(t, err)

--- a/tests/generate_test.go
+++ b/tests/generate_test.go
@@ -16,11 +16,11 @@ func TestGenerate(t *testing.T) {
 
 	out, err := ts.run("generate")
 	assert.Error(t, err)
-	assert.Equal(t, "Which name do you want to use? []: \nError: provide a password name\n", out)
+	assert.Equal(t, "Which name do you want to use? []: \nError: please provide a password name\n", out)
 
 	out, err = ts.run("generate foo 0")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: password length must be bigger than 0\n", out)
+	assert.Equal(t, "\nError: password length must not be zero\n", out)
 
 	out, err = ts.run("generate baz 42")
 	assert.NoError(t, err)

--- a/tests/grep_test.go
+++ b/tests/grep_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ func TestGrep(t *testing.T) {
 
 	out, err := ts.run("grep")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: gopass grep arg\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" grep arg\n", out)
 
 	out, err = ts.run("grep BOOM")
 	assert.NoError(t, err)

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -12,7 +12,7 @@ func TestInit(t *testing.T) {
 
 	out, err := ts.run("init")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: no interaction without terminal\n", out)
+	assert.Equal(t, "\nError: failed to initialized store: failed to read user input: no interaction without terminal\n", out)
 
 	ts = newTester(t)
 	defer ts.teardown()
@@ -29,7 +29,7 @@ func TestInit(t *testing.T) {
 	out, err = ts.run("init " + keyID)
 	assert.Error(t, err)
 	for _, o := range []string{
-		"Error: Found already initialized store at /tmp/gopass-",
+		"Found already initialized store at /tmp/gopass-",
 		"You can add secondary stores with gopass init --path <path to secondary store> --store <mount name>",
 	} {
 		assert.Contains(t, out, o)

--- a/tests/insert_test.go
+++ b/tests/insert_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ func TestInsert(t *testing.T) {
 
 	out, err := ts.run("insert")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: provide a secret name\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" insert name\n", out)
 
 	_, err = ts.runCmd([]string{ts.Binary, "insert", "some/secret"}, []byte("moar"))
 	assert.NoError(t, err)

--- a/tests/move_test.go
+++ b/tests/move_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,15 +18,15 @@ func TestMove(t *testing.T) {
 
 	out, err := ts.run("move")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: gopass mv old-path new-path\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" mv old-path new-path\n", out)
 
 	out, err = ts.run("move foo")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Usage: gopass mv old-path new-path\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" mv old-path new-path\n", out)
 
 	out, err = ts.run("move foo bar")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: Entry is not in the password store\n", out)
+	assert.Equal(t, "\nError: failed to decrypt 'foo': Entry is not in the password store\n", out)
 
 	ts.initSecrets("")
 
@@ -33,7 +34,7 @@ func TestMove(t *testing.T) {
 	assert.NoError(t, err)
 
 	out, _ = ts.run("move foo/bar foo/baz")
-	assert.Equal(t, "\nError: Entry is not in the password store\n", out)
+	assert.Equal(t, "\nError: failed to decrypt 'foo/bar': Entry is not in the password store\n", out)
 
 	_, err = ts.run("show -f bar/bar")
 	assert.NoError(t, err)

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +18,7 @@ func TestShow(t *testing.T) {
 
 	out, err := ts.run("show")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: provide a secret name\n", out)
+	assert.Equal(t, "\nError: Usage: "+filepath.Base(ts.Binary)+" show [name]\n", out)
 
 	out, err = ts.run("show foo")
 	assert.Error(t, err)
@@ -33,7 +34,7 @@ func TestShow(t *testing.T) {
 	assert.NoError(t, err)
 
 	out, _ = ts.run("show fixed/secret")
-	assert.Equal(t, "\nError: no safe content to display, you can force display with show -f\n", out)
+	assert.Equal(t, "\nError: failed to retrieve secret 'fixed/secret': no safe content to display, you can force display with show -f\n", out)
 
 	out, err = ts.run("show -f fixed/secret")
 	assert.NoError(t, err)

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -11,6 +10,7 @@ import (
 	"testing"
 
 	shellquote "github.com/kballard/go-shellquote"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -126,7 +126,7 @@ func (ts tester) teardown() {
 
 func (ts tester) runCmd(args []string, in []byte) (string, error) {
 	if len(args) < 1 {
-		return "", fmt.Errorf("no command")
+		return "", errors.Errorf("no command")
 	}
 
 	cmd := exec.Command(args[0], args[1:]...)

--- a/tests/yaml_test.go
+++ b/tests/yaml_test.go
@@ -17,7 +17,7 @@ func TestYAMLAndSecret(t *testing.T) {
 
 	out, err := ts.run("foo/bar baz")
 	assert.Error(t, err)
-	assert.Equal(t, "\nError: no YAML document marker found\n", out)
+	assert.Equal(t, "\nError: failed to retrieve key 'baz' from 'foo/bar': no YAML document marker found\n", out)
 
 	_, err = ts.runCmd([]string{ts.Binary, "insert", "foo/bar"}, []byte("moar"))
 	assert.NoError(t, err)

--- a/tpl/funcs.go
+++ b/tpl/funcs.go
@@ -5,6 +5,8 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"text/template"
+
+	"github.com/pkg/errors"
 )
 
 // These constants defined the template function names used
@@ -32,7 +34,7 @@ func get(kv kvstore) func(...string) (string, error) {
 			return "", nil
 		}
 		if kv == nil {
-			return "", fmt.Errorf("KV is nil")
+			return "", errors.Errorf("KV is nil")
 		}
 		buf, err := kv.Get(s[0])
 		if err != nil {

--- a/tree/simple/folder.go
+++ b/tree/simple/folder.go
@@ -2,11 +2,11 @@ package simple
 
 import (
 	"bytes"
-	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/justwatchcom/gopass/tree"
+	"github.com/pkg/errors"
 )
 
 // Folder is intermediate tree node
@@ -170,7 +170,7 @@ func (f *Folder) getFolder(name string) *Folder {
 func (f *Folder) FindFolder(name string) (tree.Tree, error) {
 	sub := f.findFolder(strings.Split(strings.TrimSuffix(name, "/"), "/"))
 	if sub == nil {
-		return nil, fmt.Errorf("Entry not found")
+		return nil, errors.Errorf("Entry not found")
 	}
 	return sub, nil
 }
@@ -190,12 +190,12 @@ func (f *Folder) findFolder(path []string) *Folder {
 // addFile adds new file
 func (f *Folder) addFile(path []string, contentType string) error {
 	if len(path) < 1 {
-		return fmt.Errorf("Path must not be empty")
+		return errors.Errorf("Path must not be empty")
 	}
 	name := path[0]
 	if len(path) == 1 {
 		if _, found := f.Files[name]; found {
-			return fmt.Errorf("File %s exists", name)
+			return errors.Errorf("File %s exists", name)
 		}
 		f.Files[name] = &File{
 			Name: name,
@@ -212,7 +212,7 @@ func (f *Folder) addFile(path []string, contentType string) error {
 // addMount adds a new mount (folder with non-empty on-disk path)
 func (f *Folder) addMount(path []string, dest string) error {
 	if len(path) < 1 {
-		return fmt.Errorf("Path must not be empty")
+		return errors.Errorf("Path must not be empty")
 	}
 	name := path[0]
 	if len(path) == 1 {
@@ -225,7 +225,7 @@ func (f *Folder) addMount(path []string, dest string) error {
 
 func (f *Folder) addTemplate(path []string) error {
 	if len(path) < 1 {
-		return fmt.Errorf("Path must not be empty")
+		return errors.Errorf("Path must not be empty")
 	}
 	name := path[0]
 	if len(path) == 1 {

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+	return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+	return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+	Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+	// handle specifically
+default:
+	// unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,236 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, f.msg)
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,178 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -106,6 +106,12 @@
 			"revisionTime": "2017-03-01T01:43:43Z"
 		},
 		{
+			"checksumSHA1": "QoVjlQFru1ixgV8vh63T4/JAtLI=",
+			"path": "github.com/pkg/errors",
+			"revision": "a22138067af1c4942683050411a841ade67fe1eb",
+			"revisionTime": "2016-08-08T05:55:40Z"
+		},
+		{
 			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",


### PR DESCRIPTION
This commit makes heavy use of github.com/pkg/errors to improve
handling and propagation of errors and to provide more meaningful
error messages. It also fixes some minor issues/wording wrt. error
message. Also it introduces distinct exit codes for different types
of errors.

Apart from some changes in the display output (especially when errors occur) this should
introduce no functional changes.

Fixes #150