### PR TITLE
Handle .gpg-id files in subfolders for encryption

### DIFF
--- a/store/sub/fsck.go
+++ b/store/sub/fsck.go
@@ -15,7 +15,12 @@ import (
 
 // Fsck checks this stores integrity
 func (s *Store) Fsck(prefix string, check, force bool) (map[string]uint64, error) {
-	storeRec, err := s.gpg.FindPublicKeys(s.recipients...)
+	rs, err := s.getRecipients("")
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get recipients")
+	}
+
+	storeRec, err := s.gpg.FindPublicKeys(rs...)
 	if err != nil {
 		fmt.Printf("Failed to list recipients: %s\n", err)
 	}

--- a/store/sub/gpg.go
+++ b/store/sub/gpg.go
@@ -1,8 +1,103 @@
 package sub
 
-import "github.com/blang/semver"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/blang/semver"
+	"github.com/fatih/color"
+	"github.com/justwatchcom/gopass/fsutil"
+	"github.com/pkg/errors"
+)
 
 // GPGVersion returns parsed GPG version information
 func (s *Store) GPGVersion() semver.Version {
 	return s.gpg.Version()
+}
+
+// ImportMissingPublicKeys will try to import any missing public keys from the
+// .gpg-keys folder in the password store
+func (s *Store) ImportMissingPublicKeys() error {
+	rs, err := s.getRecipients("")
+	if err != nil {
+		return errors.Wrapf(err, "failed to get recipients")
+	}
+	for _, r := range rs {
+		if s.debug {
+			fmt.Printf("[DEBUG] Checking recipients %s ...\n", r)
+		}
+		// check if this recipient is missing
+		// we could list all keys outside the loop and just do the lookup here
+		// but this way we ensure to use the exact same lookup logic as
+		// gpg does on encryption
+		kl, err := s.gpg.FindPublicKeys(r)
+		if err != nil {
+			fmt.Printf("[%s] Failed to get public key for %s: %s\n", s.alias, r, err)
+		}
+		if len(kl) > 0 {
+			fmt.Println(color.CyanString("[%s] Keyring contains %d public keys for %s", s.alias, len(kl), r))
+			continue
+		}
+
+		// we need to ask the user before importing
+		// any key material into his keyring!
+		if s.importFunc != nil {
+			if !s.importFunc(r) {
+				continue
+			}
+		}
+
+		// try to load this recipient
+		if err := s.importPublicKey(r); err != nil {
+			fmt.Println(color.RedString("[%s] Failed to import public key for %s: %s", s.alias, r, err))
+			continue
+		}
+		fmt.Println(color.GreenString("[%s] Imported public key for %s into Keyring", s.alias, r))
+	}
+	return nil
+}
+
+// export an ASCII armored public key
+func (s *Store) exportPublicKey(r string) (string, error) {
+	filename := filepath.Join(s.path, keyDir, r)
+
+	// do not overwrite existing keys
+	if fsutil.IsFile(filename) {
+		return filename, nil
+	}
+
+	tmpFilename := filename + ".new"
+	if err := s.gpg.ExportPublicKey(r, tmpFilename); err != nil {
+		return filename, err
+	}
+
+	defer func() {
+		_ = os.Remove(tmpFilename)
+	}()
+
+	fi, err := os.Stat(tmpFilename)
+	if err != nil {
+		return "", err
+	}
+
+	if fi.Size() < 1024 {
+		return "", errors.New("exported key too small")
+	}
+
+	if err := os.Rename(tmpFilename, filename); err != nil {
+		return filename, err
+	}
+
+	return filename, nil
+}
+
+// import an public key into the default keyring
+func (s *Store) importPublicKey(r string) error {
+	filename := filepath.Join(s.path, keyDir, r)
+	if !fsutil.IsFile(filename) {
+		return errors.Errorf("Public Key %s not found at %s", r, filename)
+	}
+
+	return s.gpg.ImportPublicKey(filename)
 }

--- a/store/sub/init.go
+++ b/store/sub/init.go
@@ -10,7 +10,7 @@ import (
 
 // Initialized returns true if the store is properly initialized
 func (s *Store) Initialized() bool {
-	return fsutil.IsFile(s.idFile())
+	return fsutil.IsFile(s.idFile(""))
 }
 
 // Init tries to initalize a new password store location matching the object
@@ -21,7 +21,7 @@ You can add secondary stores with gopass init --path <path to secondary store> -
 	}
 
 	// initialize recipient list
-	s.recipients = make([]string, 0, len(ids))
+	recipients := make([]string, 0, len(ids))
 
 	for _, id := range ids {
 		if id == "" {
@@ -32,14 +32,14 @@ You can add secondary stores with gopass init --path <path to secondary store> -
 			fmt.Println("Failed to fetch public key:", id)
 			continue
 		}
-		s.recipients = append(s.recipients, kl[0].Fingerprint)
+		recipients = append(recipients, kl[0].Fingerprint)
 	}
 
-	if len(s.recipients) < 1 {
+	if len(recipients) < 1 {
 		return errors.Errorf("failed to initialize store: no valid recipients given")
 	}
 
-	kl, err := s.gpg.FindPrivateKeys(s.recipients...)
+	kl, err := s.gpg.FindPrivateKeys(recipients...)
 	if err != nil {
 		return errors.Errorf("Failed to get available private keys: %s", err)
 	}
@@ -48,7 +48,7 @@ You can add secondary stores with gopass init --path <path to secondary store> -
 		return errors.Errorf("None of the recipients has a secret key. You will not be able to decrypt the secrets you add")
 	}
 
-	if err := s.saveRecipients("Initialized Store for " + strings.Join(s.recipients, ", ")); err != nil {
+	if err := s.saveRecipients(recipients, "Initialized Store for "+strings.Join(recipients, ", "), true); err != nil {
 		return errors.Errorf("failed to initialize store: %v", err)
 	}
 

--- a/store/sub/list_test.go
+++ b/store/sub/list_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	gpgmock "github.com/justwatchcom/gopass/gpg/mock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestList(t *testing.T) {
@@ -58,11 +59,13 @@ func TestList(t *testing.T) {
 		}
 
 		s := &Store{
-			alias:      "",
-			path:       tempdir,
-			gpg:        gpgmock.New(),
-			recipients: []string{"john.doe"},
+			alias: "",
+			path:  tempdir,
+			gpg:   gpgmock.New(),
 		}
+
+		err = s.saveRecipients([]string{"john.doe"}, "test", false)
+		assert.NoError(t, err)
 
 		// prepare store
 		if err := tc.prep(s); err != nil {

--- a/store/sub/move_test.go
+++ b/store/sub/move_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	gpgmock "github.com/justwatchcom/gopass/gpg/mock"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCopy(t *testing.T) {
@@ -58,11 +59,13 @@ func TestCopy(t *testing.T) {
 		}
 
 		s := &Store{
-			alias:      "",
-			path:       tempdir,
-			gpg:        gpgmock.New(),
-			recipients: []string{"john.doe"},
+			alias: "",
+			path:  tempdir,
+			gpg:   gpgmock.New(),
 		}
+
+		err = s.saveRecipients([]string{"john.doe"}, "test", false)
+		assert.NoError(t, err)
 
 		// run test case
 		t.Run(tc.name, tc.tf(s))
@@ -119,11 +122,13 @@ func TestMove(t *testing.T) {
 		}
 
 		s := &Store{
-			alias:      "",
-			path:       tempdir,
-			gpg:        gpgmock.New(),
-			recipients: []string{"john.doe"},
+			alias: "",
+			path:  tempdir,
+			gpg:   gpgmock.New(),
 		}
+
+		err = s.saveRecipients([]string{"john.doe"}, "test", false)
+		assert.NoError(t, err)
 
 		// run test case
 		t.Run(tc.name, tc.tf(s))
@@ -173,11 +178,13 @@ func TestDelete(t *testing.T) {
 		}
 
 		s := &Store{
-			alias:      "",
-			path:       tempdir,
-			gpg:        gpgmock.New(),
-			recipients: []string{"john.doe"},
+			alias: "",
+			path:  tempdir,
+			gpg:   gpgmock.New(),
 		}
+
+		err = s.saveRecipients([]string{"john.doe"}, "test", false)
+		assert.NoError(t, err)
 
 		// run test case
 		t.Run(tc.name, tc.tf(s))
@@ -258,11 +265,13 @@ func TestPrune(t *testing.T) {
 		}
 
 		s := &Store{
-			alias:      "",
-			path:       tempdir,
-			gpg:        gpgmock.New(),
-			recipients: []string{"john.doe"},
+			alias: "",
+			path:  tempdir,
+			gpg:   gpgmock.New(),
 		}
+
+		err = s.saveRecipients([]string{"john.doe"}, "test", false)
+		assert.NoError(t, err)
 
 		// run test case
 		t.Run(tc.name, tc.tf(s))

--- a/store/sub/write.go
+++ b/store/sub/write.go
@@ -39,9 +39,9 @@ func (s *Store) SetConfirm(name string, content []byte, reason string, cb store.
 		return errors.Errorf("a folder named %s already exists", name)
 	}
 
-	recipients, err := s.useableKeys()
+	recipients, err := s.useableKeys(p)
 	if err != nil {
-		return errors.Wrapf(err, "failed to list useable keys")
+		return errors.Wrapf(err, "failed to list useable keys for '%s'", p)
 	}
 
 	// confirm recipients

--- a/store/sub/yaml_test.go
+++ b/store/sub/yaml_test.go
@@ -7,6 +7,7 @@ import (
 
 	gpgmock "github.com/justwatchcom/gopass/gpg/mock"
 	"github.com/justwatchcom/gopass/store"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -250,11 +251,13 @@ ccc
 		}
 
 		s := &Store{
-			alias:      "",
-			path:       tempdir,
-			gpg:        gpgmock.New(),
-			recipients: []string{"john.doe"},
+			alias: "",
+			path:  tempdir,
+			gpg:   gpgmock.New(),
 		}
+
+		err = s.saveRecipients([]string{"john.doe"}, "test", false)
+		assert.NoError(t, err)
 
 		// run test case
 		t.Run(tc.name, tc.tf(s))


### PR DESCRIPTION
This PR implements handling of .gpg-id files in subfolders only
for encryption. This is no full support of nested .gpg-id files
but it should help with the (dangerous) issue of widening access
to certain subfolders if a pass store is edited with gopass.

Important: This adds no full sub .gpg-id support to gopass, most
noteably gopass recipients isn't aware of these nested files
and will only ever examine the topmost .gpg-id per mount.

Fixes #288

FYI: This branch is based on feature/split and should be only merged after PR #285 