### PR TITLE
Trim any trailing newlines or carriage returns in show output

### DIFF
--- a/action/show.go
+++ b/action/show.go
@@ -3,6 +3,7 @@ package action
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/atotto/clipboard"
 	"github.com/fatih/color"
@@ -91,7 +92,7 @@ func (s *Action) show(c *cli.Context, name, key string, clip, force, qr bool) er
 		}
 	}
 
-	fmt.Println(color.YellowString(string(content)))
+	fmt.Println(color.YellowString(strings.Trim(string(content), "\r\n")))
 
 	return nil
 }

--- a/action/show.go
+++ b/action/show.go
@@ -92,7 +92,7 @@ func (s *Action) show(c *cli.Context, name, key string, clip, force, qr bool) er
 		}
 	}
 
-	fmt.Println(color.YellowString(strings.Trim(string(content), "\r\n")))
+	fmt.Println(color.YellowString(strings.TrimRight(string(content), "\r\n")))
 
 	return nil
 }


### PR DESCRIPTION
Instead of getting an additional blank line in the show output you now get:

```
$ gopass foo.com
bar
$ ls
<...>
```