### PR TITLE
Minimal json api

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,10 @@ With gopass you can create templates which are searched when executing `gopass e
 
 This makes it easy to e.g. generate database passwords or use templates for certain kind of secrets.
 
+### JSON API
+
+`gopass jsonapi` enables communication with gopass via json messages. This is in particular useful for browser plugins like [gopassbridge](https://github.com/martinhoefling/gopassbridge) running gopass as native app. More details can be found in [docs/jsonapi.md](docs/jsonapi.md)
+
 ## Known Limitations and Caveats
 
 ### GnuPG

--- a/action/jsonapi.go
+++ b/action/jsonapi.go
@@ -1,0 +1,210 @@
+package action
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"github.com/justwatchcom/gopass/store"
+	"github.com/urfave/cli"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type messageType struct {
+	Type string `json:"type"`
+}
+
+type queryMessage struct {
+	Query string `json:"query"`
+}
+
+type getLoginMessage struct {
+	Entry string `json:"entry"`
+}
+
+type loginResponse struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// JSONAPI reads a json message on stdin and responds on stdout
+func (s *Action) JSONAPI(ctx context.Context, c *cli.Context) error {
+	err := readAndRespond(ctx, s)
+	if err != nil {
+		var response errorResponse
+		response.Error = err.Error()
+
+		err = sendSerializedJSONMessage(response)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func readAndRespond(ctx context.Context, s *Action) error {
+	message, err := readMessage()
+	if message != nil {
+		err = respondMessage(ctx, s, message)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func readMessage() ([]byte, error) {
+	stdin := bufio.NewReader(os.Stdin)
+	lenBytes := make([]byte, 4)
+	_, err := stdin.Read(lenBytes)
+	if err != nil {
+		return nil, eofReturn(err)
+	}
+	length, err := getMessageLength(lenBytes)
+	if err != nil {
+		return nil, err
+	}
+	msgBytes := make([]byte, length)
+	_, err = stdin.Read(msgBytes)
+	if err != nil {
+		return nil, eofReturn(err)
+	}
+	return msgBytes, nil
+}
+
+func getMessageLength(msg []byte) (int, error) {
+	var length uint32
+	buf := bytes.NewBuffer(msg)
+	err := binary.Read(buf, binary.LittleEndian, &length)
+	if err != nil {
+		return 0, err
+	}
+	return int(length), nil
+}
+
+func eofReturn(err error) error {
+	if err == io.EOF {
+		return nil
+	}
+	return err
+}
+
+func respondMessage(ctx context.Context, s *Action, msgBytes []byte) error {
+	var message messageType
+	err := json.Unmarshal(msgBytes, &message)
+	if err != nil {
+		return err
+	}
+	switch message.Type {
+	case "query":
+		return respondQuery(s, msgBytes)
+	case "getLogin":
+		return respondGetLogin(ctx, s, msgBytes)
+	default:
+		return fmt.Errorf("Unknown message of type %s", message.Type)
+	}
+}
+
+func respondQuery(s *Action, msgBytes []byte) error {
+	var message queryMessage
+	err := json.Unmarshal(msgBytes, &message)
+	if err != nil {
+		return err
+	}
+
+	l, err := s.Store.List(0)
+	if err != nil {
+		return err
+	}
+
+	needle := strings.ToLower(message.Query)
+	choices := make([]string, 0, 10)
+	for _, value := range l {
+		if strings.Contains(strings.ToLower(value), needle) {
+			choices = append(choices, value)
+		}
+	}
+
+	return sendSerializedJSONMessage(choices)
+}
+
+func respondGetLogin(ctx context.Context, s *Action, msgBytes []byte) error {
+	var message getLoginMessage
+	var response loginResponse
+
+	err := json.Unmarshal(msgBytes, &message)
+	if err != nil {
+		return err
+	}
+
+	secret, err := s.Store.Get(ctx, message.Entry)
+
+	if err != nil {
+		return err
+	}
+
+	response.Username, err = getUsername(ctx, s, message.Entry)
+	if err != nil {
+		return err
+	}
+	response.Password = secret.Password()
+
+	err = sendSerializedJSONMessage(response)
+	return err
+}
+
+func sendSerializedJSONMessage(message interface{}) error {
+	var msgBuf bytes.Buffer
+
+	serialized, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+
+	err = writeMessageLength(serialized)
+	if err != nil {
+		return err
+	}
+	_, err = msgBuf.Write(serialized)
+	if err != nil {
+		return err
+	}
+	_, err = msgBuf.WriteTo(os.Stdout)
+	return err
+}
+
+func writeMessageLength(msg []byte) error {
+	return binary.Write(os.Stdout, binary.LittleEndian, uint32(len(msg)))
+}
+
+func getUsername(ctx context.Context, s *Action, name string) (string, error) {
+	for _, key := range []string{"login", "username", "user"} {
+		secret, err := s.Store.Get(ctx, name)
+		if err != nil {
+			return "", err
+		}
+		value, err := secret.Value(key)
+		if err != nil {
+			if err != store.ErrYAMLNoKey {
+				continue
+			}
+		} else {
+			return value, nil
+		}
+	}
+
+	if strings.Count(name, "/") >= 1 {
+		return filepath.Base(name), nil
+	}
+
+	return "", nil
+}

--- a/docs/jsonapi.md
+++ b/docs/jsonapi.md
@@ -1,0 +1,53 @@
+# JSON API
+
+## Overview
+
+The API follows specification for native messaging from [Mozilla](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Native_messaging) and [Chrome](https://developer.chrome.com/apps/nativeMessaging). 
+Each json-utf8 encoded message is prefixed with a 32 bit integer specifying the length of the message. 
+Communication is performed via stdin/stdout. Currently, only a single request is repsonded `gopass jsonapi` call.
+
+## Request Types 
+
+### `query`
+
+#### Query:
+
+```json
+{
+  "type": "query",
+  "query": "secret"
+}
+```
+
+#### Response:
+
+```json
+[
+    "somewhere/mysecret/loginname", 
+    "somwhere/else/secretsauce"
+]
+```
+
+### `getLogin`
+
+#### Query:
+
+```json
+{
+   "type": "getLogin",
+   "entry": "somewhere/else/secretsauce"
+}
+```
+
+#### Response:
+
+```json
+{
+   "username": "hugo",
+   "password": "thepassword"
+}
+```
+
+
+
+

--- a/main.go
+++ b/main.go
@@ -409,6 +409,14 @@ func main() {
 			},
 		},
 		{
+			Name:        "jsonapi",
+			Usage:       "Run golang as jsonapi e.g. for browser plugins",
+			Description: "Golang reads messages from stdin and responds to stdout in this mode",
+			Action: func(c *cli.Context) error {
+				return action.JSONAPI(ctx, c)
+			},
+		},
+		{
 			Name:        "totp",
 			Usage:       "Generate time based token from stored secret",
 			Description: "Tries to parse the saved string as a time-based one-time password secret and generate a token based on the current time",

--- a/tests/jsonapi_test.go
+++ b/tests/jsonapi_test.go
@@ -1,0 +1,101 @@
+package tests
+
+import (
+	"bytes"
+	"testing"
+	"io"
+
+	"encoding/binary"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func getMessageLength(t *testing.T, msg []byte) int {
+	var length uint32
+	buf := bytes.NewBuffer(msg)
+	err := binary.Read(buf, binary.LittleEndian, &length)
+	assert.NoError(t, err)
+	return int(length)
+}
+
+func readAndVerifyMessageLength(t *testing.T, rawMessage []byte) string {
+	stdin := bytes.NewReader(rawMessage)
+	lenBytes := make([]byte, 4)
+
+	_, err := stdin.Read(lenBytes)
+	assert.NoError(t, err)
+
+	length := getMessageLength(t, lenBytes)
+	assert.NoError(t, err)
+	assert.Equal(t, len(rawMessage)-4, length)
+
+	msgBytes := make([]byte, length)
+	_, err = stdin.Read(msgBytes)
+	assert.NoError(t, err)
+	return string(msgBytes)
+}
+
+func writeMessageWithLength(message string) io.Reader {
+	buffer := bytes.NewBuffer([]byte{})
+	binary.Write(buffer, binary.LittleEndian, uint32(len(message)))
+	buffer.WriteString(message)
+	return buffer
+}
+
+func getMessageResponse(t *testing.T, ts *tester, message string) string {
+	out, err := ts.runWithInputReader("jsonapi", writeMessageWithLength(message))
+	assert.NoError(t, err)
+	return readAndVerifyMessageLength(t, out)
+}
+
+func TestJSONAPI(t *testing.T) {
+	ts := newTester(t)
+	defer ts.teardown()
+
+	ts.initStore()
+	ts.initSecrets("awesomePrefix/")
+
+	out, err := ts.runCmd([]string{ts.Binary, "insert", "awesomePrefix/fixed/yamllogin"}, []byte("thesecret\n---\nlogin: muh"))
+	require.NoError(ts.t, err, "failed to insert password:\n%s", out)
+
+	out, err = ts.runCmd([]string{ts.Binary, "insert", "awesomePrefix/fixed/yamlother"}, []byte("thesecret\n---\nother: meh"))
+	require.NoError(ts.t, err, "failed to insert password:\n%s", out)
+
+	// message has length specified but invalid json
+	strout, err := ts.runWithInput("jsonapi", "1234Xabcd")
+	assert.NoError(t, err)
+	assert.Equal(t, "{\"error\":\"invalid character 'X' looking for beginning of value\"}", readAndVerifyMessageLength(t, strout))
+
+	// empty message, no json to parse
+	response := getMessageResponse(t, ts, "")
+	assert.Equal(t, "{\"error\":\"unexpected end of JSON input\"}", response)
+
+	// message with empty object
+	response = getMessageResponse(t, ts, "{}")
+	assert.Equal(t, "{\"error\":\"Unknown message of type \"}", response)
+
+	// query for keys without any matching
+	response = getMessageResponse(t, ts, "{\"type\":\"query\",\"query\":\"notfound\"}")
+	assert.Equal(t, "[]", response)
+
+	// query for keys with matching one
+	response = getMessageResponse(t, ts, "{\"type\":\"query\",\"query\":\"foo\"}")
+	assert.Equal(t, "[\"awesomePrefix/foo/bar\"]", response)
+
+	// query for keys with matching multiple
+	response = getMessageResponse(t, ts, "{\"type\":\"query\",\"query\":\"yaml\"}")
+	assert.Equal(t, "[\"awesomePrefix/fixed/yamllogin\",\"awesomePrefix/fixed/yamlother\"]", response)
+
+	// get username / password for key without value in yaml
+	response = getMessageResponse(t, ts, "{\"type\":\"getLogin\",\"entry\":\"awesomePrefix/fixed/secret\"}")
+	assert.Equal(t, "{\"username\":\"secret\",\"password\":\"moar\"}", response)
+
+	// get username / password for key with login in yaml
+	response = getMessageResponse(t, ts, "{\"type\":\"getLogin\",\"entry\":\"awesomePrefix/fixed/yamllogin\"}")
+	assert.Equal(t, "{\"username\":\"muh\",\"password\":\"thesecret\"}", response)
+
+	// get username / password for key with no login in yaml (fallback)
+	response = getMessageResponse(t, ts, "{\"type\":\"getLogin\",\"entry\":\"awesomePrefix/fixed/yamlother\"}")
+	assert.Equal(t, "{\"username\":\"yamlother\",\"password\":\"thesecret\"}", response)
+}

--- a/tests/jsonapi_test.go
+++ b/tests/jsonapi_test.go
@@ -2,8 +2,8 @@ package tests
 
 import (
 	"bytes"
-	"testing"
 	"io"
+	"testing"
 
 	"encoding/binary"
 


### PR DESCRIPTION
Implementation of a minimal set of messages (query and getLogin + Responses). Integration tests for use and edge cases are implemented. Let me know if something is missing. Further, I rebased on two commits of @dominikschulz to make the tests run on OSX - so merging is only possible after his commits are reviewed and merged. Please comment and discuss the implementation.