### PR TITLE
Only confirm recipients once

### DIFF
--- a/action/clihelper.go
+++ b/action/clihelper.go
@@ -162,7 +162,7 @@ func (s *Action) AskForKeyImport(ctx context.Context, key string) bool {
 	if !ctxutil.IsInteractive(ctx) {
 		return false
 	}
-	ok, err := s.askForBool("Do you want to import the public key '%s' into your keyring?", false)
+	ok, err := s.askForBool(fmt.Sprintf("Do you want to import the public key '%s' into your keyring?", key), false)
 	if err != nil {
 		return false
 	}

--- a/action/recipients.go
+++ b/action/recipients.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/justwatchcom/gopass/utils/ctxutil"
 	"github.com/urfave/cli"
 )
 
@@ -83,7 +84,7 @@ func (s *Action) RecipientsAdd(ctx context.Context, c *cli.Context) error {
 			continue
 		}
 
-		if err := s.Store.AddRecipient(ctx, store, keys[0].Fingerprint); err != nil {
+		if err := s.Store.AddRecipient(ctxutil.WithNoConfirm(ctx, true), store, keys[0].Fingerprint); err != nil {
 			return s.exitError(ctx, ExitRecipients, err, "failed to add recipient '%s': %s", r, err)
 		}
 		added++
@@ -109,7 +110,7 @@ func (s *Action) RecipientsRemove(ctx context.Context, c *cli.Context) error {
 				}
 			}
 		}
-		if err := s.Store.RemoveRecipient(ctx, store, strings.TrimPrefix(r, "0x")); err != nil {
+		if err := s.Store.RemoveRecipient(ctxutil.WithNoConfirm(ctx, true), store, strings.TrimPrefix(r, "0x")); err != nil {
 			return s.exitError(ctx, ExitRecipients, err, "failed to remove recipient '%s': %s", r, err)
 		}
 		fmt.Printf(removalWarning, r)


### PR DESCRIPTION
When adding a new recipient do not confirm the recipient list for
every secret but only once.

Fixes #316

Actually the bug described in #316 was already fixed during the config/context refactoring, but during testing some annoying behavior (asking to confirm the recipients for every secret) surfaced, so this PR fixes that.