### PR TITLE
Fix config value propagation

### DIFF
--- a/config/context.go
+++ b/config/context.go
@@ -8,15 +8,25 @@ import (
 )
 
 // WithContext returns a context with all config options set for this store
-// config
+// config, iff they have not been already set in the context
 func (c StoreConfig) WithContext(ctx context.Context) context.Context {
-	ctx = ctxutil.WithAskForMore(ctx, c.AskForMore)
+	if !ctxutil.HasAskForMore(ctx) {
+		ctx = ctxutil.WithAskForMore(ctx, c.AskForMore)
+	}
 	if !c.AutoImport {
 		ctx = sub.WithImportFunc(ctx, nil)
 	}
-	ctx = sub.WithAutoSync(ctx, c.AutoSync)
-	ctx = ctxutil.WithClipTimeout(ctx, c.ClipTimeout)
-	ctx = ctxutil.WithNoConfirm(ctx, c.NoConfirm)
-	ctx = ctxutil.WithShowSafeContent(ctx, c.SafeContent)
+	if !sub.HasAutoSync(ctx) {
+		ctx = sub.WithAutoSync(ctx, c.AutoSync)
+	}
+	if !ctxutil.HasClipTimeout(ctx) {
+		ctx = ctxutil.WithClipTimeout(ctx, c.ClipTimeout)
+	}
+	if !ctxutil.HasNoConfirm(ctx) {
+		ctx = ctxutil.WithNoConfirm(ctx, c.NoConfirm)
+	}
+	if !ctxutil.HasShowSafeContent(ctx) {
+		ctx = ctxutil.WithShowSafeContent(ctx, c.SafeContent)
+	}
 	return ctx
 }

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	"github.com/justwatchcom/gopass/utils/ctxutil"
+)
+
+func TestContext(t *testing.T) {
+	ctx := context.Background()
+
+	sc := StoreConfig{
+		AskForMore: true,
+		NoConfirm:  false,
+	}
+
+	// should return the default value from the store config
+	if ctxutil.IsNoConfirm(sc.WithContext(ctx)) {
+		t.Errorf("NoConfirm should be false")
+	}
+
+	// after overwriting the noconfirm value in the context,
+	// it should not be overwritten by the store config value
+	ctx = ctxutil.WithNoConfirm(ctx, true)
+
+	if !ctxutil.IsNoConfirm(sc.WithContext(ctx)) {
+		t.Errorf("NoConfirm should be true")
+	}
+}

--- a/store/sub/context.go
+++ b/store/sub/context.go
@@ -24,6 +24,13 @@ func WithFsckCheck(ctx context.Context, check bool) context.Context {
 	return context.WithValue(ctx, ctxKeyFsckCheck, check)
 }
 
+// HasFsckCheck returns true if a value for fsck check has been set in this
+// context
+func HasFsckCheck(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyFsckCheck).(bool)
+	return ok
+}
+
 // IsFsckCheck returns the value of fsck check
 func IsFsckCheck(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyFsckCheck).(bool)
@@ -36,6 +43,13 @@ func IsFsckCheck(ctx context.Context) bool {
 // WithFsckForce returns a context with the flag for fsck force set
 func WithFsckForce(ctx context.Context, force bool) context.Context {
 	return context.WithValue(ctx, ctxKeyFsckForce, force)
+}
+
+// HasFsckForce returns true if a value for fsck force has been set in this
+// context
+func HasFsckForce(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyFsckForce).(bool)
+	return ok
 }
 
 // IsFsckForce returns the value of fsck force
@@ -52,6 +66,13 @@ func WithAutoSync(ctx context.Context, sync bool) context.Context {
 	return context.WithValue(ctx, ctxKeyAutoSync, sync)
 }
 
+// HasAutoSync has been set if a value for auto sync has been set in this
+// context
+func HasAutoSync(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyAutoSync).(bool)
+	return ok
+}
+
 // IsAutoSync returns the value of autosync
 func IsAutoSync(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyAutoSync).(bool)
@@ -66,6 +87,12 @@ func WithReason(ctx context.Context, msg string) context.Context {
 	return context.WithValue(ctx, ctxKeyReason, msg)
 }
 
+// HasReason returns true if a value for reason has been set in this context
+func HasReason(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyReason).(bool)
+	return ok
+}
+
 // GetReason returns the value of reason
 func GetReason(ctx context.Context) string {
 	sv, ok := ctx.Value(ctxKeyReason).(string)
@@ -78,6 +105,13 @@ func GetReason(ctx context.Context) string {
 // WithImportFunc will return a context with the import callback set
 func WithImportFunc(ctx context.Context, imf store.ImportCallback) context.Context {
 	return context.WithValue(ctx, ctxKeyImportFunc, imf)
+}
+
+// HasImportFunc returns true if a value for import func has been set in this
+// context
+func HasImportFunc(ctx context.Context) bool {
+	imf, ok := ctx.Value(ctxKeyImportFunc).(store.ImportCallback)
+	return ok && imf != nil
 }
 
 // GetImportFunc will return the import callback or a default one returning true
@@ -95,6 +129,13 @@ func GetImportFunc(ctx context.Context) store.ImportCallback {
 // WithRecipientFunc will return a context with the recipient callback set
 func WithRecipientFunc(ctx context.Context, imf store.RecipientCallback) context.Context {
 	return context.WithValue(ctx, ctxKeyRecipientFunc, imf)
+}
+
+// HasRecipientFunc returns true if a recipient func has been set in this
+// context
+func HasRecipientFunc(ctx context.Context) bool {
+	imf, ok := ctx.Value(ctxKeyRecipientFunc).(store.RecipientCallback)
+	return ok && imf != nil
 }
 
 // GetRecipientFunc will return the recipient callback or a default one returning
@@ -115,6 +156,12 @@ func WithFsckFunc(ctx context.Context, imf store.FsckCallback) context.Context {
 	return context.WithValue(ctx, ctxKeyFsckFunc, imf)
 }
 
+// HasFsckFunc returns true if a fsck func has been set in this context
+func HasFsckFunc(ctx context.Context) bool {
+	imf, ok := ctx.Value(ctxKeyFsckFunc).(store.FsckCallback)
+	return ok && imf != nil
+}
+
 // GetFsckFunc will return the fsck confirmation callback or a default one
 // returning true.
 // Note: will never return nil
@@ -132,6 +179,13 @@ func GetFsckFunc(ctx context.Context) store.FsckCallback {
 // set
 func WithCheckRecipients(ctx context.Context, cr bool) context.Context {
 	return context.WithValue(ctx, ctxKeyCheckRecipients, cr)
+}
+
+// HasCheckRecipients returns true if check recipients has been set in this
+// context
+func HasCheckRecipients(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyCheckRecipients).(bool)
+	return ok
 }
 
 // IsCheckRecipients will return the value of the check recipients flag or the

--- a/store/sub/recipients.go
+++ b/store/sub/recipients.go
@@ -177,16 +177,15 @@ func (s *Store) saveRecipients(ctx context.Context, rs []string, msg string, exp
 		return errors.Wrapf(err, "failed to write recipients file")
 	}
 
-	err := s.gitAdd(ctx, idf)
-	if err == nil {
-		if err := s.gitCommit(ctx, msg); err != nil {
-			if err != store.ErrGitNotInit && err != store.ErrGitNothingToCommit {
-				return errors.Wrapf(err, "failed to commit changes to git")
-			}
-		}
-	} else {
+	if err := s.gitAdd(ctx, idf); err != nil {
 		if err != store.ErrGitNotInit {
 			return errors.Wrapf(err, "failed to add file '%s' to git", idf)
+		}
+	}
+
+	if err := s.gitCommit(ctx, msg); err != nil {
+		if err != store.ErrGitNotInit && err != store.ErrGitNothingToCommit {
+			return errors.Wrapf(err, "failed to commit changes to git")
 		}
 	}
 

--- a/store/sub/write.go
+++ b/store/sub/write.go
@@ -32,13 +32,11 @@ func (s *Store) Set(ctx context.Context, name string, sec *secret.Secret) error 
 	}
 
 	// confirm recipients
-	if cb := GetRecipientFunc(ctx); cb != nil {
-		newRecipients, err := cb(ctx, name, recipients)
-		if err != nil {
-			return errors.Wrapf(err, "user aborted")
-		}
-		recipients = newRecipients
+	newRecipients, err := GetRecipientFunc(ctx)(ctx, name, recipients)
+	if err != nil {
+		return errors.Wrapf(err, "user aborted")
 	}
+	recipients = newRecipients
 
 	buf, err := sec.Bytes()
 	if err != nil {

--- a/utils/ctxutil/ctxutil.go
+++ b/utils/ctxutil/ctxutil.go
@@ -24,6 +24,12 @@ func WithDebug(ctx context.Context, dbg bool) context.Context {
 	return context.WithValue(ctx, ctxKeyDebug, dbg)
 }
 
+// HasDebug returns true if a value for debug has been set in this context
+func HasDebug(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyDebug).(bool)
+	return ok
+}
+
 // IsDebug returns the value of debug or the default (false)
 func IsDebug(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyDebug).(bool)
@@ -36,6 +42,12 @@ func IsDebug(ctx context.Context) bool {
 // WithColor returns a context with an explizit value for color
 func WithColor(ctx context.Context, color bool) context.Context {
 	return context.WithValue(ctx, ctxKeyColor, color)
+}
+
+// HasColor returns true if a value for Color has been set in this context
+func HasColor(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyColor).(bool)
+	return ok
 }
 
 // IsColor returns the value of color or the default (true)
@@ -52,6 +64,12 @@ func WithTerminal(ctx context.Context, isTerm bool) context.Context {
 	return context.WithValue(ctx, ctxKeyTerminal, isTerm)
 }
 
+// HasTerminal returns true if a value for Terminal has been set in this context
+func HasTerminal(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyTerminal).(bool)
+	return ok
+}
+
 // IsTerminal returns the value of terminal or the default (true)
 func IsTerminal(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyTerminal).(bool)
@@ -64,6 +82,12 @@ func IsTerminal(ctx context.Context) bool {
 // WithInteractive returns a context with an explizit value for interactive
 func WithInteractive(ctx context.Context, isInteractive bool) context.Context {
 	return context.WithValue(ctx, ctxKeyInteractive, isInteractive)
+}
+
+// HasInteractive returns true if a value for Interactive has been set in this context
+func HasInteractive(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyInteractive).(bool)
+	return ok
 }
 
 // IsInteractive returns the value of interactive or the default (true)
@@ -81,6 +105,12 @@ func WithStdin(ctx context.Context, isStdin bool) context.Context {
 	return context.WithValue(ctx, ctxKeyStdin, isStdin)
 }
 
+// HasStdin returns true if a value for Stdin has been set in this context
+func HasStdin(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyStdin).(bool)
+	return ok
+}
+
 // IsStdin returns the value of stdin, i.e. if it's true some data is being
 // piped to stdin. If not set it returns the default value (false)
 func IsStdin(ctx context.Context) bool {
@@ -94,6 +124,12 @@ func IsStdin(ctx context.Context) bool {
 // WithAskForMore returns a context with the value for ask for more set
 func WithAskForMore(ctx context.Context, afm bool) context.Context {
 	return context.WithValue(ctx, ctxKeyAskForMore, afm)
+}
+
+// HasAskForMore returns true if a value for AskForMore has been set in this context
+func HasAskForMore(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyAskForMore).(bool)
+	return ok
 }
 
 // IsAskForMore returns the value of ask for more or the default (false)
@@ -110,6 +146,12 @@ func WithClipTimeout(ctx context.Context, to int) context.Context {
 	return context.WithValue(ctx, ctxKeyClipTimeout, to)
 }
 
+// HasClipTimeout returns true if a value for ClipTimeout has been set in this context
+func HasClipTimeout(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyClipTimeout).(int)
+	return ok
+}
+
 // GetClipTimeout returns the value of clip timeout or the default (45)
 func GetClipTimeout(ctx context.Context) int {
 	iv, ok := ctx.Value(ctxKeyClipTimeout).(int)
@@ -122,6 +164,12 @@ func GetClipTimeout(ctx context.Context) int {
 // WithNoConfirm returns a context with the value for ask for more set
 func WithNoConfirm(ctx context.Context, bv bool) context.Context {
 	return context.WithValue(ctx, ctxKeyNoConfirm, bv)
+}
+
+// HasNoConfirm returns true if a value for NoConfirm has been set in this context
+func HasNoConfirm(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyNoConfirm).(bool)
+	return ok
 }
 
 // IsNoConfirm returns the value of ask for more or the default (false)
@@ -138,6 +186,12 @@ func WithNoPager(ctx context.Context, bv bool) context.Context {
 	return context.WithValue(ctx, ctxKeyNoPager, bv)
 }
 
+// HasNoPager returns true if a value for NoPager has been set in this context
+func HasNoPager(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyNoPager).(bool)
+	return ok
+}
+
 // IsNoPager returns the value of ask for more or the default (false)
 func IsNoPager(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyNoPager).(bool)
@@ -150,6 +204,12 @@ func IsNoPager(ctx context.Context) bool {
 // WithShowSafeContent returns a context with the value for ask for more set
 func WithShowSafeContent(ctx context.Context, bv bool) context.Context {
 	return context.WithValue(ctx, ctxKeyShowSafeContent, bv)
+}
+
+// HasShowSafeContent returns true if a value for ShowSafeContent has been set in this context
+func HasShowSafeContent(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyShowSafeContent).(bool)
+	return ok
 }
 
 // IsShowSafeContent returns the value of ask for more or the default (false)
@@ -166,6 +226,12 @@ func WithGitCommit(ctx context.Context, bv bool) context.Context {
 	return context.WithValue(ctx, ctxKeyGitCommit, bv)
 }
 
+// HasGitCommit returns true if a value for GitCommit has been set in this context
+func HasGitCommit(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyShowSafeContent).(bool)
+	return ok
+}
+
 // IsGitCommit returns the value of git commit or the default (true)
 func IsGitCommit(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyGitCommit).(bool)
@@ -178,6 +244,12 @@ func IsGitCommit(ctx context.Context) bool {
 // WithAlwaysYes returns a context with the value of always yes set
 func WithAlwaysYes(ctx context.Context, bv bool) context.Context {
 	return context.WithValue(ctx, ctxKeyAlwaysYes, bv)
+}
+
+// HasAlwaysYes returns true if a value for AlwaysYes has been set in this context
+func HasAlwaysYes(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyAlwaysYes).(bool)
+	return ok
 }
 
 // IsAlwaysYes returns the value of always yes or the default (false)

--- a/utils/ctxutil/ctxutil_test.go
+++ b/utils/ctxutil/ctxutil_test.go
@@ -6,61 +6,110 @@ import (
 )
 
 func TestDebug(t *testing.T) {
-	if IsDebug(context.Background()) {
+	ctx := context.Background()
+
+	if IsDebug(ctx) {
 		t.Errorf("Vanilla ctx should not be debug")
 	}
-	if !IsDebug(WithDebug(context.Background(), true)) {
+	if !IsDebug(WithDebug(ctx, true)) {
 		t.Errorf("Should have debug flag")
 	}
-	if IsDebug(WithDebug(context.Background(), false)) {
+	if IsDebug(WithDebug(ctx, false)) {
 		t.Errorf("Should not have debug flag")
 	}
 }
 
 func TestColor(t *testing.T) {
-	if !IsColor(context.Background()) {
+	ctx := context.Background()
+
+	if !IsColor(ctx) {
 		t.Errorf("Vanilla ctx should have color")
 	}
-	if !IsColor(WithColor(context.Background(), true)) {
+	if !IsColor(WithColor(ctx, true)) {
 		t.Errorf("Should have color flag")
 	}
-	if IsColor(WithColor(context.Background(), false)) {
+	if IsColor(WithColor(ctx, false)) {
 		t.Errorf("Should not have color flag")
 	}
 }
 
 func TestTerminal(t *testing.T) {
-	if !IsTerminal(context.Background()) {
+	ctx := context.Background()
+
+	if !IsTerminal(ctx) {
 		t.Errorf("Vanilla ctx should be terminal")
 	}
-	if !IsTerminal(WithTerminal(context.Background(), true)) {
+	if !IsTerminal(WithTerminal(ctx, true)) {
 		t.Errorf("Should have terminal flag")
 	}
-	if IsTerminal(WithTerminal(context.Background(), false)) {
+	if IsTerminal(WithTerminal(ctx, false)) {
 		t.Errorf("Should not have terminal flag")
 	}
 }
 
 func TestInteractive(t *testing.T) {
-	if !IsInteractive(context.Background()) {
+	ctx := context.Background()
+
+	if !IsInteractive(ctx) {
 		t.Errorf("Vanilla ctx should be interactive")
 	}
-	if !IsInteractive(WithInteractive(context.Background(), true)) {
+	if !IsInteractive(WithInteractive(ctx, true)) {
 		t.Errorf("Should have interactive flag")
 	}
-	if IsInteractive(WithInteractive(context.Background(), false)) {
+	if IsInteractive(WithInteractive(ctx, false)) {
 		t.Errorf("Should not have interactive flag")
 	}
 }
 
 func TestComposite(t *testing.T) {
 	ctx := context.Background()
-	ctx = WithColor(ctx, true)
+	ctx = WithDebug(ctx, true)
+	ctx = WithColor(ctx, false)
 	ctx = WithTerminal(ctx, false)
 	ctx = WithInteractive(ctx, false)
-	ctx = WithColor(ctx, false)
+	ctx = WithStdin(ctx, true)
+	ctx = WithAskForMore(ctx, true)
+	ctx = WithClipTimeout(ctx, 10)
+	ctx = WithNoConfirm(ctx, true)
+	ctx = WithNoPager(ctx, true)
+	ctx = WithShowSafeContent(ctx, true)
+	ctx = WithGitCommit(ctx, false)
+	ctx = WithAlwaysYes(ctx, true)
 
+	if !IsDebug(ctx) {
+		t.Errorf("Debug should be true")
+	}
 	if IsColor(ctx) {
 		t.Errorf("Color should be false")
+	}
+	if IsTerminal(ctx) {
+		t.Errorf("Termiunal should be false")
+	}
+	if IsInteractive(ctx) {
+		t.Errorf("IsInteractive should be false")
+	}
+	if !IsStdin(ctx) {
+		t.Errorf("IsStdin should be true")
+	}
+	if !IsAskForMore(ctx) {
+		t.Errorf("Ask for more should be true")
+	}
+	if GetClipTimeout(ctx) != 10 {
+		t.Errorf("Clip timeout should be 10")
+	}
+	if !IsNoConfirm(ctx) {
+		t.Errorf("NoConfirm should be true")
+	}
+	if !IsNoPager(ctx) {
+		t.Errorf("NoPager should be true")
+	}
+	if !IsShowSafeContent(ctx) {
+		t.Errorf("ShowSafeContexnt should be true")
+	}
+	if IsGitCommit(ctx) {
+		t.Errorf("Git commit should be false")
+	}
+	if !IsAlwaysYes(ctx) {
+		t.Errorf("Always yes should be true")
 	}
 }


### PR DESCRIPTION
Applying the per-store config must not overwrite any previously set context values.

Simple change, but rather verbose.

Fixes #354