### PR TITLE
Setup method for native messaging wrapper and manifest

### DIFF
--- a/main.go
+++ b/main.go
@@ -437,10 +437,47 @@ func main() {
 		},
 		{
 			Name:        "jsonapi",
-			Usage:       "Run golang as jsonapi e.g. for browser plugins",
-			Description: "Golang reads messages from stdin and responds to stdout in this mode",
-			Action: func(c *cli.Context) error {
-				return action.JSONAPI(ctx, c)
+			Usage:       "Run gopass as jsonapi e.g. for browser plugins",
+			Description: "Setup and run gopass as native messaging hosts, e.g. for browser plugins.",
+			Subcommands: []cli.Command{
+				{
+					Name:        "listen",
+					Usage:       "Listen and respond to messages via stdin/stdout",
+					Description: "Gopass is started in listen mode from browser plugins using a wrapper specified in native messaging host manifests",
+					Action: func(c *cli.Context) error {
+						return action.JSONAPI(withGlobalFlags(ctx, c), c)
+					},
+				},
+				{
+					Name:        "configure",
+					Usage:       "Setup gopass native messaging manifest for selected browser",
+					Description: "To access gopass from browser plugins, a native app manifest must be installed at the correct location",
+					Action: func(c *cli.Context) error {
+						return action.SetupNativeMessaging(withGlobalFlags(ctx, c), c)
+					},
+					Flags: []cli.Flag{
+						cli.StringFlag{
+							Name:  "browser",
+							Usage: "One of 'chrome' and 'firefox'",
+						},
+						cli.StringFlag{
+							Name:  "path",
+							Usage: "Path to install 'gopass_wrapper.sh' to",
+						},
+						cli.BoolFlag{
+							Name:  "global",
+							Usage: "Install for all users, requires superuser rights",
+						},
+						cli.StringFlag{
+							Name:  "libpath",
+							Usage: "Library path for global installation on linux. Default is /usr/lib",
+						},
+						cli.BoolFlag{
+							Name:  "print-only",
+							Usage: "only print installation summary but do not actually create any files",
+						},
+					},
+				},
 			},
 		},
 		{

--- a/tests/jsonapi_test.go
+++ b/tests/jsonapi_test.go
@@ -44,7 +44,7 @@ func writeMessageWithLength(message string) io.Reader {
 }
 
 func getMessageResponse(t *testing.T, ts *tester, message string) string {
-	out, err := ts.runWithInputReader("jsonapi", writeMessageWithLength(message))
+	out, err := ts.runWithInputReader("jsonapi listen", writeMessageWithLength(message))
 	assert.NoError(t, err)
 	return readAndVerifyMessageLength(t, out)
 }
@@ -78,7 +78,7 @@ func TestJSONAPI(t *testing.T) {
 	require.NoError(ts.t, err, "failed to insert password:\n%s", out)
 
 	// message has length specified but invalid json
-	strout, err := ts.runWithInput("jsonapi", "1234Xabcd")
+	strout, err := ts.runWithInput("jsonapi listen", "1234Xabcd")
 	assert.NoError(t, err)
 	assert.Equal(t, "{\"error\":\"incomplete message read\"}", readAndVerifyMessageLength(t, strout))
 

--- a/utils/jsonapi/manifest/constants.go
+++ b/utils/jsonapi/manifest/constants.go
@@ -1,0 +1,52 @@
+package manifest
+
+var wrapperTemplate = `#!/bin/bash
+
+if [ -f ~/.gpg-agent-info ] && [ -n "$(pgrep gpg-agent)" ]; then
+source ~/.gpg-agent-info
+export GPG_AGENT_INFO
+else
+eval $(gpg-agent --daemon)
+fi
+
+export PATH="$PATH:/usr/local/bin" # required on MacOS/brew
+export GPG_TTY="$(tty)"
+%s jsonapi listen
+exit $?`
+
+// DefaultBrowser to select when no browser is specified
+var DefaultBrowser = "chrome"
+
+// DefaultWrapperPath where the gopass wrapper shell script is installed to
+var DefaultWrapperPath = "/usr/local/bin"
+
+// ValidBrowsers are all browsers for which the manifest can be currently installed
+var ValidBrowsers = []string{"chrome", "chromium", "firefox"}
+
+var name = "com.justwatch.gopass"
+var wrapperName = "gopass_wrapper.sh"
+var description = "Gopass wrapper to search and return passwords"
+var connectionType = "stdio"
+var chromeOrigins = []string{
+	"chrome-extension://kkhfnlkhiapbiehimabddjbimfaijdhk/", // gopassbridge
+}
+var firefoxOrigins = []string{
+	"{eec37db0-22ad-4bf1-9068-5ae08df8c7e9}", // gopassbridge
+}
+
+type manifestBase struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Path        string `json:"path"`
+	Type        string `json:"type"`
+}
+
+type chromeManifest struct {
+	manifestBase
+	AllowedOrigins []string `json:"allowed_origins"`
+}
+
+type firefoxManifest struct {
+	manifestBase
+	AllowedExtensions []string `json:"allowed_extensions"`
+}

--- a/utils/jsonapi/manifest/location.go
+++ b/utils/jsonapi/manifest/location.go
@@ -1,0 +1,69 @@
+package manifest
+
+import (
+	"fmt"
+	"path"
+	"runtime"
+)
+
+func getLocation(browser, libpath string, globalInstall bool) (string, error) {
+	switch platform := runtime.GOOS; platform {
+	case "darwin":
+		{
+			switch browser {
+			case "firefox":
+				{
+					if globalInstall {
+						return "/Library/Application Support/Mozilla/NativeMessagingHosts/%s.json", nil
+					}
+					return "~/Library/Application Support/Mozilla/NativeMessagingHosts/%s.json", nil
+				}
+			case "chrome":
+				{
+					if globalInstall {
+						return "/Library/Google/Chrome/NativeMessagingHosts/%s.json", nil
+					}
+					return "~/Library/Application Support/Google/Chrome/NativeMessagingHosts/%s.json", nil
+				}
+			case "chromium":
+				{
+					if globalInstall {
+						return "/Library/Application Support/Chromium/NativeMessagingHosts/%s.json", nil
+					}
+					return "~/Library/Application Support/Chromium/NativeMessagingHosts/%s.json", nil
+				}
+			}
+		}
+	case "linux":
+		{
+			switch browser {
+			case "firefox":
+				{
+					if globalInstall {
+						return path.Join(libpath, "mozilla/native-messaging-hosts/%s.json"), nil
+					}
+					return "~/.mozilla/native-messaging-hosts/%s.json", nil
+				}
+			case "chrome":
+				{
+					if globalInstall {
+						return "/etc/opt/chrome/native-messaging-hosts/%s.json", nil
+					}
+					return "~/.config/google-chrome/NativeMessagingHosts/%s.json", nil
+				}
+			case "chromium":
+				{
+					if globalInstall {
+						return "/etc/chromium/native-messaging-hosts/%s.json", nil
+					}
+					return "~/.config/chromium/NativeMessagingHosts/%s.json", nil
+				}
+			}
+		}
+	default:
+		{
+			return "", fmt.Errorf("platform %s is currently not supported", platform)
+		}
+	}
+	return "", nil
+}

--- a/utils/jsonapi/manifest/setup.go
+++ b/utils/jsonapi/manifest/setup.go
@@ -1,0 +1,151 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path"
+
+	"io/ioutil"
+
+	"path/filepath"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+type configuredFile struct {
+	path    string
+	content string
+}
+
+// PrintSummary prints path and content of manifest and wrapper script
+func PrintSummary(browser, wrapperPath, libpath string, global bool) error {
+	manifestFile, err := getManifest(browser, wrapperPath, libpath, global)
+	if err != nil {
+		return err
+	}
+
+	printConfiguredFile("Native Messaging Host Manifest", manifestFile)
+
+	wrapperFile, err := getWrapper(wrapperPath)
+	if err != nil {
+		return err
+	}
+	printConfiguredFile("Wrapper", wrapperFile)
+
+	return nil
+}
+
+// SetUp actually creates the manifest and wrapper scripts
+func SetUp(browser, wrapperPath, libpath string, global bool) error {
+	manifestFile, err := getManifest(browser, wrapperPath, libpath, global)
+	if err != nil {
+		return err
+	}
+	if err := writeConfiguredFile("Manifest", manifestFile, 0644); err != nil {
+		return err
+	}
+
+	wrapperFile, err := getWrapper(wrapperPath)
+	if err != nil {
+		return err
+	}
+
+	return writeConfiguredFile("Wrapper", wrapperFile, 0755)
+}
+
+func printConfiguredFile(preamble string, file configuredFile) {
+	fmt.Println(preamble)
+	fmt.Printf("\npath: %s\n", file.path)
+	fmt.Printf("\n### File content: ###\n%s\n###\n\n", file.content)
+}
+
+func writeConfiguredFile(name string, file configuredFile, perm os.FileMode) error {
+	dir := filepath.Dir(file.path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(file.path, []byte(file.content), perm); err != nil {
+		return err
+	}
+	fmt.Printf("\n%s written to %s\n", name, file.path)
+	return nil
+}
+
+func getManifest(browser, wrapperPath, libpath string, global bool) (configuredFile, error) {
+	file := configuredFile{}
+	manifestPath, err := getManifestPath(browser, libpath, global)
+	if err != nil {
+		return file, err
+	}
+	file.path = manifestPath
+	file.content, err = getManifestContent(browser, wrapperPath)
+	if err != nil {
+		return file, err
+	}
+	return file, nil
+}
+
+func getWrapper(wrapperPath string) (configuredFile, error) {
+	file := configuredFile{path: path.Join(wrapperPath, wrapperName)}
+	gopassPath, err := getGopassPath()
+	if err != nil {
+		return file, err
+	}
+	file.content = getWrapperContent(gopassPath)
+	return file, nil
+}
+
+func getManifestPath(browser, libpath string, globalInstall bool) (string, error) {
+	location, err := getLocation(browser, libpath, globalInstall)
+	if err != nil {
+		return "", err
+	}
+
+	expanded, err := homedir.Expand(location)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf(expanded, name), nil
+}
+
+func getGopassPath() (string, error) {
+	return os.Executable()
+}
+
+func getWrapperContent(gopassPath string) string {
+	return fmt.Sprintf(wrapperTemplate, gopassPath)
+}
+
+func getManifestContent(browser, wrapperPath string) (string, error) {
+	var bytes []byte
+	var err error
+
+	if browser == "firefox" {
+		jsonManifest := firefoxManifest{}
+		jsonManifest.InitFields(path.Join(wrapperPath, wrapperName))
+		jsonManifest.AllowedExtensions = firefoxOrigins
+		bytes, err = json.MarshalIndent(jsonManifest, "", "    ")
+	} else if browser == "chrome" || browser == "chromium" {
+		jsonManifest := chromeManifest{}
+		jsonManifest.InitFields(path.Join(wrapperPath, wrapperName))
+		jsonManifest.AllowedOrigins = chromeOrigins
+		bytes, err = json.MarshalIndent(jsonManifest, "", "    ")
+	} else {
+		return "", fmt.Errorf("no manifest template for browser %s", browser)
+	}
+
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func (m *manifestBase) InitFields(wrapperPath string) {
+	m.Name = name
+	m.Type = connectionType
+	m.Path = wrapperPath
+	m.Description = description
+}


### PR DESCRIPTION
I've split `gopass jsonapi` into `gopass jsonapi listen` and `gopass jsonapi configure`. Here, I implemented the manifest configuration for chrome, chromium and firefox on OSX and Linux. Global installation is supported as well as specifying an alternate lib path on linux.

Currently, the wrapper is installed in /usr/local/bin which requires superuser privileges on linux but not on OSX with brew. What are your thoughts on this? Installing them alongside with the gopass config would also be an option.

Tests: ... any ideas what would be meaningful tests? They should be platform independent right? So I've tested the functionality by hand on osx and linux.

I've also updated the gopassbridge plugins for firefox and chrome to 0.0.5 and published them so that with that changes - a normal user should be able to set up its browser.