### PR TITLE
Do not enforce YAML parsing

### DIFF
--- a/store/secret/secret.go
+++ b/store/secret/secret.go
@@ -45,13 +45,10 @@ func Parse(buf []byte) (*Secret, error) {
 
 // decodeYAML attempts to decode an optional YAML part of a secret
 func (s *Secret) decodeYAML() (bool, error) {
-	if !strings.HasPrefix(s.body, "---\n") {
-		return false, nil
-	}
 	d := make(map[string]interface{})
 	err := yaml.Unmarshal([]byte(s.body), &d)
 	if err != nil {
-		return true, err
+		return false, nil
 	}
 	s.data = d
 	s.body = ""


### PR DESCRIPTION
Try to parse in YAML and give up silently if it fails

Some tools (e.g. [the lastpass importer])https://git.zx2c4.com/password-store/tree/contrib/importers/lastpass2pass.rb#n60) create invalid YAML which makes `gopass` crash. It seems easier and safer to just try and parse in YAML, and give up without crashing otherwise.