### PR TITLE
allow find to take -c

### DIFF
--- a/action/find.go
+++ b/action/find.go
@@ -31,9 +31,11 @@ func (s *Action) Find(ctx context.Context, c *cli.Context) error {
 		}
 	}
 
+	clip := c.Bool("clip")
+
 	if len(choices) == 1 {
 		fmt.Println(color.GreenString("Found exact match in '%s'", choices[0]))
-		return s.show(ctx, c, choices[0], "", false, false, false, false)
+		return s.show(ctx, c, choices[0], "", clip, false, false, false)
 	}
 
 	if len(choices) < 1 {
@@ -61,7 +63,7 @@ func (s *Action) Find(ctx context.Context, c *cli.Context) error {
 	case "show":
 		// display selected entry
 		fmt.Println(choices[sel])
-		return s.show(ctx, c, choices[sel], "", false, false, false, false)
+		return s.show(ctx, c, choices[sel], "", clip, false, false, false)
 	default:
 		return s.exitError(ctx, ExitAborted, nil, "user aborted")
 	}

--- a/main.go
+++ b/main.go
@@ -378,6 +378,12 @@ func main() {
 			},
 			Aliases:      []string{"search"},
 			BashComplete: action.Complete,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "clip, c",
+					Usage: "Copy the password into the clipboard",
+				},
+			},
 		},
 		{
 			Name:        "fsck",


### PR DESCRIPTION
If -c is passed to find (or to show and it does a find) don't show the password even if asked to.

Possible implementation for #377 