### PR TITLE
Improve onboarding

### DIFF
--- a/action/clone.go
+++ b/action/clone.go
@@ -26,10 +26,14 @@ func (s *Action) Clone(ctx context.Context, c *cli.Context) error {
 	}
 
 	path := c.String("path")
+
+	return s.clone(ctx, repo, mount, path)
+}
+
+func (s *Action) clone(ctx context.Context, repo, mount, path string) error {
 	if path == "" {
 		path = config.PwStoreDir(mount)
 	}
-
 	if mount == "" && s.Store.Initialized() {
 		return s.exitError(ctx, ExitAlreadyInitialized, nil, "Can not clone %s to the root store, as this store is already initialized. Please try cloning to a submount: `%s clone %s sub`", repo, s.Name, repo)
 	}


### PR DESCRIPTION
This commit adds three very simple first drafts of onboarding
wizards that should help setup gopass for the most common use
cases. There is still a lot of room for improvements, but this
should be a start.

Fixes #97
Fixes #98