### PR TITLE
Expose onboarding wizard as gopass setup

### DIFF
--- a/action/clihelper.go
+++ b/action/clihelper.go
@@ -79,6 +79,10 @@ func (s *Action) AskForConfirmation(ctx context.Context, text string) bool {
 // The empty answer uses the specified default, any other answer
 // is an error.
 func (s *Action) askForBool(ctx context.Context, text string, def bool) (bool, error) {
+	if ctxutil.IsAlwaysYes(ctx) {
+		return def, nil
+	}
+
 	choices := "y/N"
 	if def {
 		choices = "Y/n"
@@ -109,10 +113,14 @@ func (s *Action) askForBool(ctx context.Context, text string, def bool) (bool, e
 // askForString asks for a string once, using the default if the
 // anser is empty. Errors are only returned on I/O errors
 func (s *Action) askForString(ctx context.Context, text, def string) (string, error) {
+	if ctxutil.IsAlwaysYes(ctx) {
+		return def, nil
+	}
+
 	// check for context cancelation
 	select {
 	case <-ctx.Done():
-		return "", errors.New("user aborted")
+		return def, errors.New("user aborted")
 	default:
 	}
 
@@ -133,6 +141,10 @@ func (s *Action) askForString(ctx context.Context, text, def string) (string, er
 // askForInt asks for an valid interger once. If the input
 // can not be converted to an int it returns an error
 func (s *Action) askForInt(ctx context.Context, text string, def int) (int, error) {
+	if ctxutil.IsAlwaysYes(ctx) {
+		return def, nil
+	}
+
 	str, err := s.askForString(ctx, text, strconv.Itoa(def))
 	if err != nil {
 		return 0, err

--- a/main.go
+++ b/main.go
@@ -169,7 +169,7 @@ func main() {
 	}
 
 	app.Action = func(c *cli.Context) error {
-		if err := action.Initialized(ctx, c); err != nil {
+		if err := action.Initialized(withGlobalFlags(ctx, c), c); err != nil {
 			return err
 		}
 
@@ -742,6 +742,27 @@ func main() {
 							Usage: "Store to operate on",
 						},
 					},
+				},
+			},
+		},
+		{
+			Name:  "setup",
+			Usage: "Initialize a new password store.",
+			Action: func(c *cli.Context) error {
+				return action.InitOnboarding(withGlobalFlags(ctx, c), c)
+			},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "remote",
+					Usage: "URL to a git remote, will attempt to join this team",
+				},
+				cli.StringFlag{
+					Name:  "alias",
+					Usage: "Local mount point for the given remote",
+				},
+				cli.BoolFlag{
+					Name:  "create",
+					Usage: "Create a new team (default: false, i.e. join an existing team)",
 				},
 			},
 		},


### PR DESCRIPTION
This commit exposes the onboarding wizard explizitly as the
setup subcommand which also accepts commandline parameters
for unattended setups.