### PR TITLE
Do not show find result selection on gopass find

### DIFF
--- a/action/find.go
+++ b/action/find.go
@@ -47,7 +47,7 @@ func (s *Action) Find(ctx context.Context, c *cli.Context) error {
 		}
 	}
 
-	if !ctxutil.IsTerminal(ctx) {
+	if !ctxutil.IsTerminal(ctx) || c.Command.Name == "find" {
 		for _, value := range choices {
 			fmt.Println(value)
 		}


### PR DESCRIPTION
This commit changes the behaviour of gopass to only show the result
selection prompt when a search was triggered indirect (i.e. gopass show)
but not on gopass search/find.

Fixes #397