### PR TITLE
add new 'usesymbols' config option.

### DIFF
--- a/action/generate.go
+++ b/action/generate.go
@@ -25,7 +25,10 @@ func (s *Action) Generate(ctx context.Context, c *cli.Context) error {
 	var xkcdSeparator string
 	force := c.Bool("force")
 	edit := c.Bool("edit")
-	symbols := c.Bool("symbols")
+	symbols := false
+	if c.Bool("symbols") || ctxutil.IsUseSymbols(ctx) {
+		symbols = true
+	}
 	xkcd := c.Bool("xkcd")
 	if c.IsSet("xkcdsep") {
 		xkcdSeparator = c.String("xkcdsep")
@@ -33,7 +36,7 @@ func (s *Action) Generate(ctx context.Context, c *cli.Context) error {
 	}
 
 	if c.IsSet("no-symbols") {
-		out.Red(ctx, "Warning: -n/--no-symbols is deprecated. This is now the default. Use -s to enable symbols")
+		out.Red(ctx, "Warning: -n/--no-symbols is deprecated. This is now the default. Use -s to enable symbols. You can also set 'usesymbols' to true via gopass config.")
 	}
 
 	name := c.Args().Get(0)

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,7 @@ func New() *Config {
 			NoConfirm:   false,
 			NoPager:     false,
 			SafeContent: false,
+			UseSymbols:  false,
 		},
 		Mounts:  make(map[string]*StoreConfig),
 		Version: "",

--- a/config/store_config.go
+++ b/config/store_config.go
@@ -19,6 +19,7 @@ type StoreConfig struct {
 	NoPager     bool   `yaml:"nopager"`     // do not invoke a pager to display long lists
 	Path        string `yaml:"path"`        // path to the root store
 	SafeContent bool   `yaml:"safecontent"` // avoid showing passwords in terminal
+	UseSymbols  bool   `yaml:"usesymbols"`  // always use symbols when generating passwords
 }
 
 // ConfigMap returns a map of stringified config values for easy printing

--- a/docs/config.md
+++ b/docs/config.md
@@ -31,3 +31,4 @@ This is a list of options available:
 | `noconfirm`   | `bool`   | Do not confirm recipient list when encrypting. |
 | `path`        | `string` | Path to the root store. |
 | `safecontent` | `bool`   | Only output _safe content_ (i.e. everything but the first line of a secret) to the terminal. Use _copy_ (`-c`) to retrieve the password in the clipboard. |
+| `usesymbols`  | `bool`   | If enabled - it will use symbols when generating passwords. |

--- a/main.go
+++ b/main.go
@@ -80,6 +80,9 @@ func main() {
 	// show safe content
 	ctx = ctxutil.WithShowSafeContent(ctx, cfg.Root.SafeContent)
 
+	// always use symbols
+	ctx = ctxutil.WithUseSymbols(ctx, cfg.Root.UseSymbols)
+
 	// check recipients conflicts with always trust, make sure it's not enabled
 	// when always trust is
 	if gpg.IsAlwaysTrust(ctx) {

--- a/utils/ctxutil/ctxutil.go
+++ b/utils/ctxutil/ctxutil.go
@@ -17,6 +17,7 @@ const (
 	ctxKeyShowSafeContent
 	ctxKeyGitCommit
 	ctxKeyAlwaysYes
+	ctxKeyUseSymbols
 )
 
 // WithDebug returns a context with an explizit value for debug
@@ -237,6 +238,26 @@ func IsGitCommit(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyGitCommit).(bool)
 	if !ok {
 		return true
+	}
+	return bv
+}
+
+// WithUseSymbols returns a context with the value for ask for more set
+func WithUseSymbols(ctx context.Context, bv bool) context.Context {
+	return context.WithValue(ctx, ctxKeyUseSymbols, bv)
+}
+
+// HasNoSymbols returns true if a value for UseSymbols has been set in this context
+func HasUseSymbols(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyUseSymbols).(bool)
+	return ok
+}
+
+// IsUseSymbols returns the value of ask for more or the default (false)
+func IsUseSymbols(ctx context.Context) bool {
+	bv, ok := ctx.Value(ctxKeyUseSymbols).(bool)
+	if !ok {
+		return false
 	}
 	return bv
 }

--- a/utils/ctxutil/ctxutil.go
+++ b/utils/ctxutil/ctxutil.go
@@ -247,7 +247,7 @@ func WithUseSymbols(ctx context.Context, bv bool) context.Context {
 	return context.WithValue(ctx, ctxKeyUseSymbols, bv)
 }
 
-// HasNoSymbols returns true if a value for UseSymbols has been set in this context
+// HasUseSymbols returns true if a value for UseSymbols has been set in this context
 func HasUseSymbols(ctx context.Context) bool {
 	_, ok := ctx.Value(ctxKeyUseSymbols).(bool)
 	return ok

--- a/utils/ctxutil/ctxutil_test.go
+++ b/utils/ctxutil/ctxutil_test.go
@@ -74,6 +74,7 @@ func TestComposite(t *testing.T) {
 	ctx = WithNoPager(ctx, true)
 	ctx = WithShowSafeContent(ctx, true)
 	ctx = WithGitCommit(ctx, false)
+	ctx = WithUseSymbols(ctx, false)
 	ctx = WithAlwaysYes(ctx, true)
 
 	if !IsDebug(ctx) {
@@ -108,6 +109,9 @@ func TestComposite(t *testing.T) {
 	}
 	if IsGitCommit(ctx) {
 		t.Errorf("Git commit should be false")
+	}
+	if IsUseSymbols(ctx) {
+		t.Errorf("UseSymbols should be false")
 	}
 	if !IsAlwaysYes(ctx) {
 		t.Errorf("Always yes should be true")


### PR DESCRIPTION
This lets users always use symbols (or not) via the config file.
