### PR TITLE
add config option to toggle colored output

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,7 @@ func New() *Config {
 			NoPager:     false,
 			SafeContent: false,
 			UseSymbols:  false,
+			NoColor:     false,
 		},
 		Mounts:  make(map[string]*StoreConfig),
 		Version: "",

--- a/config/store_config.go
+++ b/config/store_config.go
@@ -20,6 +20,7 @@ type StoreConfig struct {
 	Path        string `yaml:"path"`        // path to the root store
 	SafeContent bool   `yaml:"safecontent"` // avoid showing passwords in terminal
 	UseSymbols  bool   `yaml:"usesymbols"`  // always use symbols when generating passwords
+	NoColor     bool   `yaml:"nocolor"`     // do not use color when outputing text
 }
 
 // ConfigMap returns a map of stringified config values for easy printing

--- a/docs/config.md
+++ b/docs/config.md
@@ -32,3 +32,4 @@ This is a list of options available:
 | `path`        | `string` | Path to the root store. |
 | `safecontent` | `bool`   | Only output _safe content_ (i.e. everything but the first line of a secret) to the terminal. Use _copy_ (`-c`) to retrieve the password in the clipboard. |
 | `usesymbols`  | `bool`   | If enabled - it will use symbols when generating passwords. |
+| `nocolor`     | `bool`   | Do not use color. |

--- a/main.go
+++ b/main.go
@@ -83,6 +83,9 @@ func main() {
 	// always use symbols
 	ctx = ctxutil.WithUseSymbols(ctx, cfg.Root.UseSymbols)
 
+	// never use color
+	ctx = ctxutil.WithNoColor(ctx, cfg.Root.NoColor)
+
 	// check recipients conflicts with always trust, make sure it's not enabled
 	// when always trust is
 	if gpg.IsAlwaysTrust(ctx) {
@@ -95,7 +98,7 @@ func main() {
 	}
 
 	// need this override for our integration tests
-	if nc := os.Getenv("GOPASS_NOCOLOR"); nc == "true" {
+	if nc := os.Getenv("GOPASS_NOCOLOR"); nc == "true" || ctxutil.IsNoColor(ctx) {
 		color.NoColor = true
 		ctx = ctxutil.WithColor(ctx, false)
 	}

--- a/utils/ctxutil/ctxutil.go
+++ b/utils/ctxutil/ctxutil.go
@@ -18,6 +18,7 @@ const (
 	ctxKeyGitCommit
 	ctxKeyAlwaysYes
 	ctxKeyUseSymbols
+	ctxKeyNoColor
 )
 
 // WithDebug returns a context with an explizit value for debug
@@ -256,6 +257,26 @@ func HasUseSymbols(ctx context.Context) bool {
 // IsUseSymbols returns the value of ask for more or the default (false)
 func IsUseSymbols(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyUseSymbols).(bool)
+	if !ok {
+		return false
+	}
+	return bv
+}
+
+// WithNoColor returns a context with the value for ask for more set
+func WithNoColor(ctx context.Context, bv bool) context.Context {
+	return context.WithValue(ctx, ctxKeyNoColor, bv)
+}
+
+// HasNoColor returns true if a value for NoColor has been set in this context
+func HasNoColor(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyNoColor).(bool)
+	return ok
+}
+
+// IsNoColor returns the value of ask for more or the default (false)
+func IsNoColor(ctx context.Context) bool {
+	bv, ok := ctx.Value(ctxKeyNoColor).(bool)
 	if !ok {
 		return false
 	}

--- a/utils/ctxutil/ctxutil_test.go
+++ b/utils/ctxutil/ctxutil_test.go
@@ -76,6 +76,7 @@ func TestComposite(t *testing.T) {
 	ctx = WithGitCommit(ctx, false)
 	ctx = WithUseSymbols(ctx, false)
 	ctx = WithAlwaysYes(ctx, true)
+	ctx = WithNoColor(ctx, true)
 
 	if !IsDebug(ctx) {
 		t.Errorf("Debug should be true")


### PR DESCRIPTION
`make tests` passes this time. Previously I had only run `make test` and `make test-integration`, because apparently `s` is invisible to me :D
