### PR TITLE
Correcting the dmenu cmd in the docs

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -189,7 +189,7 @@ Since writing fish completion scripts is not yet supported by the CLI library we
 
 In earlier versions gopass supported [dmenu](http://tools.suckless.org/dmenu/). We removed this and encourage you to call dmenu yourself now.
 
-This also makes it easier to call gopass with [rofi](https://github.com/DaveDavenport/rofi), for example.
+This also makes it easier to call gopass with any drop-in replacement of dmenu, like [rofi](https://github.com/DaveDavenport/rofi), for example, since you would just need to replace the `dmenu` call below by `rofi -dmenu`.
 
 ```bash
 # Simply copy the selected password to the clipboard
@@ -197,6 +197,8 @@ gopass ls --flat | dmenu | xargs --no-run-if-empty gopass show -c
 # First pipe the selected name to gopass, encrypt it and type the password with xdotool.
 gopass ls --flat | dmenu | xargs --no-run-if-empty gopass show -f | head -n 1 | xdotool type --clearmodifiers --file -
 ```
+
+You can then simply bind these command lines to your preferred shortcuts in your window manager settings, typically under `System Settings > Keyboard > Shortcuts > Custom Shortcuts`.
 
 ### Filling in passwords from browser
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -195,7 +195,7 @@ This also makes it easier to call gopass with [rofi](https://github.com/DaveDave
 # Simply copy the selected password to the clipboard
 gopass ls --flat | dmenu | xargs --no-run-if-empty gopass show -c
 # First pipe the selected name to gopass, encrypt it and type the password with xdotool.
-gopass ls --flat | dmenu | xargs --no-run-if-empty gopass show | head -n 1 | xdotool type --clearmodifiers --file -
+gopass ls --flat | dmenu | xargs --no-run-if-empty gopass show -f | head -n 1 | xdotool type --clearmodifiers --file -
 ```
 
 ### Filling in passwords from browser


### PR DESCRIPTION
Since if the setting `safecontent` is set to `true`, it won't work as it. 

In order to be sure to get the password on the first line no matter what, you need to use the `-f` flag. (Which do nothing if `safecontent` is set to `false`)

I've also added a few details about what you actually want to do with those cmd lines in practice.