### PR TITLE
Add initial appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,23 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\gopath\src\github.com\justwatchcom\gopass
+
+environment:
+  GOPATH: c:\gopath
+  GOPASS_BINARY: c:\gopath\src\github.com\justwatchcom\gopass\gopass.exe
+
+install:
+    - echo %PATH%
+    - echo %GOPATH%
+    - go version
+    - go env
+#    - ps: |
+#        go.exe get -t -d (go.exe list ./... `
+#        |? { -not $_.Contains('/vendor/') })
+
+build_script:
+    - go build
+    - ps: |
+        go.exe test (go.exe list ./... | where { -not $_.Contains('/vendor/') -and -not $_.Contains('/tests') })


### PR DESCRIPTION
This PR adds a first version of an appveyor.yml to support CI test on windows.
At the moment this excludes the integration tests but the plan is to get those working as well in the future.