### PR TITLE
Improved documentation and more useful default for wrapper dir

### DIFF
--- a/action/jsonapi.go
+++ b/action/jsonapi.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/justwatchcom/gopass/config"
 	"github.com/justwatchcom/gopass/utils/jsonapi"
 	"github.com/justwatchcom/gopass/utils/jsonapi/manifest"
 	"github.com/pkg/errors"
@@ -91,7 +92,7 @@ func (s *Action) getLibPath(ctx context.Context, c *cli.Context, browser string,
 func (s *Action) getWrapperPath(ctx context.Context, c *cli.Context) (path string, err error) {
 	path = c.String("path")
 	if path == "" {
-		path, err = s.askForString(ctx, color.BlueString("In which path should gopass_wrapper.sh be installed?"), manifest.DefaultWrapperPath)
+		path, err = s.askForString(ctx, color.BlueString("In which path should gopass_wrapper.sh be installed?"), config.Directory())
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to ask for user input")
 		}

--- a/config/io.go
+++ b/config/io.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	"github.com/justwatchcom/gopass/utils/fsutil"
 	"github.com/pkg/errors"
@@ -108,7 +107,7 @@ func (c *Config) Save() error {
 		return errors.Wrapf(err, "failed to marshal YAML")
 	}
 	cfgLoc := configLocation()
-	cfgDir := filepath.Dir(cfgLoc)
+	cfgDir := Directory()
 	if !fsutil.IsDir(cfgDir) {
 		if err := os.MkdirAll(cfgDir, 0700); err != nil {
 			return errors.Wrapf(err, "failed to create dir '%s'", cfgDir)

--- a/config/io.go
+++ b/config/io.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/justwatchcom/gopass/utils/fsutil"
 	"github.com/pkg/errors"
@@ -107,7 +108,7 @@ func (c *Config) Save() error {
 		return errors.Wrapf(err, "failed to marshal YAML")
 	}
 	cfgLoc := configLocation()
-	cfgDir := Directory()
+	cfgDir := filepath.Dir(cfgLoc)
 	if !fsutil.IsDir(cfgDir) {
 		if err := os.MkdirAll(cfgDir, 0700); err != nil {
 			return errors.Wrapf(err, "failed to create dir '%s'", cfgDir)

--- a/config/location.go
+++ b/config/location.go
@@ -67,3 +67,9 @@ func PwStoreDir(mount string) string {
 	}
 	return filepath.Join(Homedir(), ".password-store")
 }
+
+// Directory returns the configuration directory for the gopass config file
+func Directory() string {
+	cfgLoc := configLocation()
+	return filepath.Dir(cfgLoc)
+}

--- a/config/location.go
+++ b/config/location.go
@@ -70,6 +70,5 @@ func PwStoreDir(mount string) string {
 
 // Directory returns the configuration directory for the gopass config file
 func Directory() string {
-	cfgLoc := configLocation()
-	return filepath.Dir(cfgLoc)
+	return filepath.Dir(configLocation())
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -217,6 +217,8 @@ gopass jsonapi configure --print-only
 gopass jsonapi configure --browser chrome --path /home/user/.local/
 
 ```
+
+The username/login is determined from `login`, `username` and `user` yaml attributes. As fallback, the last part of the path is used, e.g. `theuser1` for `Internet/github.com/theuser1` entry.
  
 ### Storing and Syncing your Password Store with Google Drive / Dropbox / etc.
 


### PR DESCRIPTION
Documentation how the username is determined.

Use the config directory instead of /usr/local/bin as default for wrapper. This has two main advantages:
- guaranteed to be writeable for the user
- not in $PATH, so `gopass_wrapper.sh` won't block autocompletion.