### PR TITLE
Don't try to update any HEAD build, regardless of version

### DIFF
--- a/action/version.go
+++ b/action/version.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/dominikschulz/github-releases/ghrel"
@@ -26,7 +27,7 @@ func (s *Action) Version(ctx context.Context, c *cli.Context) error {
 			return
 		}
 
-		if s.version.String() == "0.0.0+HEAD" {
+		if strings.HasSuffix(s.version.String(), "+HEAD") {
 			// chan not check version against HEAD
 			u <- ""
 			return


### PR DESCRIPTION
I think the original check is faulty, as it's never supposed to try and update a HEAD build, regardless of the exact version. This also leads to the problem, that gopass currently thinks that 1.6.0-git+HEAD is updateable to 1.6.0 stable.

This change cancels the update check for all manual HEAD builds.