### PR TITLE
Bail early if we have protector is enabled

### DIFF
--- a/action/version.go
+++ b/action/version.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dominikschulz/github-releases/ghrel"
 	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/utils/out"
+	"github.com/justwatchcom/gopass/utils/protect"
 	"github.com/urfave/cli"
 )
 
@@ -27,8 +28,9 @@ func (s *Action) Version(ctx context.Context, c *cli.Context) error {
 			return
 		}
 
-		if strings.HasSuffix(s.version.String(), "+HEAD") {
-			// chan not check version against HEAD
+		if strings.HasSuffix(s.version.String(), "+HEAD") || protect.ProtectEnabled {
+			// chan not check version against HEAD or
+			// against pledge(2)'d OpenBSD
 			u <- ""
 			return
 		}

--- a/utils/protect/protect.go
+++ b/utils/protect/protect.go
@@ -2,6 +2,9 @@
 
 package protect
 
+// ProtectEnabled lets us know if we have protection or not
+var ProtectEnabled = false
+
 // Pledge on any other system than OpenBSD doesn't do anything
 func Pledge(s string) {
 	return

--- a/utils/protect/protect_openbsd.go
+++ b/utils/protect/protect_openbsd.go
@@ -4,6 +4,9 @@ package protect
 
 import "golang.org/x/sys/unix"
 
+// ProtectEnabled lets us know if we have protection or not
+var ProtectEnabled = true
+
 // Pledge on OpenBSD lets us "promise" to only run a subset of
 // system calls: http://man.openbsd.org/pledge
 func Pledge(s string) {


### PR DESCRIPTION
As pointed out in #469, the pledging breaks the version check.
My testing "worked" because of the HEAD check..

Since we typically disable remote version checks in OpenBSD anyway
(doing an update would break the package otherwise), we might as
well disable it here.