### PR TITLE
Adding concurrency for reencrypt

### DIFF
--- a/pkg/action/config_test.go
+++ b/pkg/action/config_test.go
@@ -44,6 +44,7 @@ func TestConfig(t *testing.T) {
   autoimport: true
   autosync: true
   cliptimeout: 45
+  concurrency: 1
   editrecipients: false
   nocolor: false
   noconfirm: false
@@ -87,6 +88,7 @@ foo/nopager: false`
   autoimport: true
   autosync: true
   cliptimeout: 45
+  concurrency: 1
   editrecipients: false
   nocolor: false
   noconfirm: false
@@ -105,7 +107,7 @@ mount 'foo' config:
   notifications: false
 `
 	want += "  path: " + backend.FromPath("").String()
-	assert.Equal(t, want, strings.TrimSpace(buf.String()), "action.setConfigValues")
+	assert.Equal(t, want, strings.TrimSpace(buf.String()), "action.printConfigValues")
 	buf.Reset()
 
 	delete(act.cfg.Mounts, "foo")
@@ -134,6 +136,7 @@ autoclip
 autoimport
 autosync
 cliptimeout
+concurrency
 editrecipients
 nocolor
 noconfirm

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ func New() *Config {
 			AutoImport:    true,
 			AutoSync:      true,
 			ClipTimeout:   45,
+			Concurrency:   1,
 			NoColor:       false,
 			NoConfirm:     false,
 			NoPager:       false,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -23,7 +23,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, backend.GPGCLI, cfg.Root.Path.Crypto)
 	assert.Equal(t, backend.GitCLI, cfg.Root.Path.RCS)
 	assert.Equal(t, backend.FS, cfg.Root.Path.Storage)
-	assert.Equal(t, "Config[Root:StoreConfig[AskForMore:false,AutoClip:true,AutoImport:true,AutoSync:true,ClipTimeout:45,EditRecipients:false,NoColor:false,NoConfirm:false,NoPager:false,Notifications:true,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false],Mounts(),Version:]", cfg.String())
+	assert.Equal(t, "Config[Root:StoreConfig[AskForMore:false,AutoClip:true,AutoImport:true,AutoSync:true,ClipTimeout:45,Concurrency:1,EditRecipients:false,NoColor:false,NoConfirm:false,NoPager:false,Notifications:true,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false],Mounts(),Version:]", cfg.String())
 
 	cfg = nil
 	assert.Error(t, cfg.checkDefaults())
@@ -34,7 +34,7 @@ func TestNewConfig(t *testing.T) {
 	cfg.Mounts["foo"] = &StoreConfig{}
 	cfg.Mounts["bar"] = &StoreConfig{}
 	assert.NoError(t, cfg.checkDefaults())
-	assert.Equal(t, "Config[Root:StoreConfig[AskForMore:false,AutoClip:false,AutoImport:false,AutoSync:false,ClipTimeout:0,EditRecipients:false,NoColor:false,NoConfirm:false,NoPager:false,Notifications:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false],Mounts(bar=>StoreConfig[AskForMore:false,AutoClip:false,AutoImport:false,AutoSync:false,ClipTimeout:0,EditRecipients:false,NoColor:false,NoConfirm:false,NoPager:false,Notifications:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false]foo=>StoreConfig[AskForMore:false,AutoClip:false,AutoImport:false,AutoSync:false,ClipTimeout:0,EditRecipients:false,NoColor:false,NoConfirm:false,NoPager:false,Notifications:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false]),Version:]", cfg.String())
+	assert.Equal(t, "Config[Root:StoreConfig[AskForMore:false,AutoClip:false,AutoImport:false,AutoSync:false,ClipTimeout:0,Concurrency:1,EditRecipients:false,NoColor:false,NoConfirm:false,NoPager:false,Notifications:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false],Mounts(bar=>StoreConfig[AskForMore:false,AutoClip:false,AutoImport:false,AutoSync:false,ClipTimeout:0,Concurrency:1,EditRecipients:false,NoColor:false,NoConfirm:false,NoPager:false,Notifications:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false]foo=>StoreConfig[AskForMore:false,AutoClip:false,AutoImport:false,AutoSync:false,ClipTimeout:0,Concurrency:1,EditRecipients:false,NoColor:false,NoConfirm:false,NoPager:false,Notifications:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false]),Version:]", cfg.String())
 }
 
 func TestSetConfigValue(t *testing.T) {

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -25,6 +25,9 @@ func (c StoreConfig) WithContext(ctx context.Context) context.Context {
 	if !ctxutil.HasClipTimeout(ctx) {
 		ctx = ctxutil.WithClipTimeout(ctx, c.ClipTimeout)
 	}
+	if !ctxutil.HasConcurrency(ctx) {
+		ctx = ctxutil.WithConcurrency(ctx, c.Concurrency)
+	}
 	if !ctxutil.HasNoConfirm(ctx) {
 		ctx = ctxutil.WithNoConfirm(ctx, c.NoConfirm)
 	}

--- a/pkg/config/store_config.go
+++ b/pkg/config/store_config.go
@@ -18,6 +18,7 @@ type StoreConfig struct {
 	AutoImport     bool         `yaml:"autoimport"`     // import missing public keys w/o asking
 	AutoSync       bool         `yaml:"autosync"`       // push to git remote after commit, pull before push if necessary
 	ClipTimeout    int          `yaml:"cliptimeout"`    // clear clipboard after seconds
+	Concurrency    int          `yaml:"concurrency"`    // allow to run multiple thread when batch processing
 	EditRecipients bool         `yaml:"editrecipients"` // edit recipients when confirming
 	NoColor        bool         `yaml:"nocolor"`        // do not use color when outputing text
 	NoConfirm      bool         `yaml:"noconfirm"`      // do not confirm recipients when encrypting
@@ -34,6 +35,9 @@ func (c *StoreConfig) checkDefaults() error {
 	}
 	if c.Path == nil {
 		c.Path = backend.FromPath("")
+	}
+	if c.Concurrency == 0 {
+		c.Concurrency = 1
 	}
 	return nil
 }
@@ -116,5 +120,5 @@ func (c *StoreConfig) SetConfigValue(key, value string) error {
 }
 
 func (c *StoreConfig) String() string {
-	return fmt.Sprintf("StoreConfig[AskForMore:%t,AutoClip:%t,AutoImport:%t,AutoSync:%t,ClipTimeout:%d,EditRecipients:%t,NoColor:%t,NoConfirm:%t,NoPager:%t,Notifications:%t,Path:%s,SafeContent:%t,UseSymbols:%t]", c.AskForMore, c.AutoClip, c.AutoImport, c.AutoSync, c.ClipTimeout, c.EditRecipients, c.NoColor, c.NoConfirm, c.NoPager, c.Notifications, c.Path, c.SafeContent, c.UseSymbols)
+	return fmt.Sprintf("StoreConfig[AskForMore:%t,AutoClip:%t,AutoImport:%t,AutoSync:%t,ClipTimeout:%d,Concurrency:%d,EditRecipients:%t,NoColor:%t,NoConfirm:%t,NoPager:%t,Notifications:%t,Path:%s,SafeContent:%t,UseSymbols:%t]", c.AskForMore, c.AutoClip, c.AutoImport, c.AutoSync, c.ClipTimeout, c.Concurrency, c.EditRecipients, c.NoColor, c.NoConfirm, c.NoPager, c.Notifications, c.Path, c.SafeContent, c.UseSymbols)
 }

--- a/pkg/ctxutil/ctxutil.go
+++ b/pkg/ctxutil/ctxutil.go
@@ -12,6 +12,7 @@ const (
 	ctxKeyStdin
 	ctxKeyAskForMore
 	ctxKeyClipTimeout
+	ctxKeyConcurrency
 	ctxKeyNoConfirm
 	ctxKeyNoPager
 	ctxKeyShowSafeContent
@@ -406,4 +407,28 @@ func IsEditRecipients(ctx context.Context) bool {
 		return false
 	}
 	return bv
+}
+
+// WithConcurrency returns a context with the value for clip timeout set
+func WithConcurrency(ctx context.Context, to int) context.Context {
+	return context.WithValue(ctx, ctxKeyConcurrency, to)
+}
+
+// HasConcurrency returns true if a value for Concurrency has been set in this context and is bigger than 1
+// since if it is equal to 1, we are not working concurrently.
+func HasConcurrency(ctx context.Context) bool {
+	iv, ok := ctx.Value(ctxKeyConcurrency).(int)
+	if iv <= 1 {
+		return false
+	}
+	return ok
+}
+
+// GetConcurrency returns the value of concurrent threads or the default (1)
+func GetConcurrency(ctx context.Context) int {
+	iv, ok := ctx.Value(ctxKeyConcurrency).(int)
+	if !ok || iv < 1 {
+		return 1
+	}
+	return iv
 }

--- a/pkg/ctxutil/ctxutil_test.go
+++ b/pkg/ctxutil/ctxutil_test.go
@@ -62,6 +62,13 @@ func TestClipTimeout(t *testing.T) {
 	assert.Equal(t, 30, GetClipTimeout(WithClipTimeout(ctx, 30)))
 }
 
+func TestConcurrency(t *testing.T) {
+	ctx := context.Background()
+
+	assert.Equal(t, 1, GetConcurrency(ctx))
+	assert.Equal(t, 3, GetConcurrency(WithConcurrency(ctx, 3)))
+}
+
 func TestNoConfirm(t *testing.T) {
 	ctx := context.Background()
 
@@ -167,6 +174,7 @@ func TestComposite(t *testing.T) {
 	ctx = WithStdin(ctx, true)
 	ctx = WithAskForMore(ctx, true)
 	ctx = WithClipTimeout(ctx, 10)
+	ctx = WithConcurrency(ctx, 5)
 	ctx = WithNoConfirm(ctx, true)
 	ctx = WithNoPager(ctx, true)
 	ctx = WithShowSafeContent(ctx, true)
@@ -200,6 +208,9 @@ func TestComposite(t *testing.T) {
 
 	assert.Equal(t, 10, GetClipTimeout(ctx))
 	assert.Equal(t, true, HasClipTimeout(ctx))
+
+	assert.Equal(t, 5, GetConcurrency(ctx))
+	assert.Equal(t, true, HasConcurrency(ctx))
 
 	assert.Equal(t, true, IsNoConfirm(ctx))
 	assert.Equal(t, true, HasNoConfirm(ctx))

--- a/pkg/store/sub/write.go
+++ b/pkg/store/sub/write.go
@@ -54,6 +54,13 @@ func (s *Store) Set(ctx context.Context, name string, sec store.Secret) error {
 		return errors.Wrapf(err, "failed to write secret")
 	}
 
+	// It is not possible to perform concurrent git add and git commit commands
+	// so we need to skip this step when using concurrency and perform them
+	// at the end of the batch processing.
+	if ctxutil.HasConcurrency(ctx) {
+		return nil
+	}
+
 	if err := s.rcs.Add(ctx, p); err != nil {
 		if errors.Cause(err) == store.ErrGitNotInit {
 			return nil

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -16,6 +16,7 @@ func TestConfig(t *testing.T) {
 	assert.Contains(t, out, "autoimport: true")
 	assert.Contains(t, out, "autosync: false")
 	assert.Contains(t, out, "cliptimeout: 45")
+	assert.Contains(t, out, "concurrency: 1")
 	assert.Contains(t, out, "noconfirm: true")
 	assert.Contains(t, out, "path: ")
 	assert.Contains(t, out, "safecontent: true")
@@ -45,4 +46,8 @@ func TestConfig(t *testing.T) {
 	out, err = ts.run("config cliptimeout")
 	assert.NoError(t, err)
 	assert.Equal(t, "cliptimeout: 120", out)
+
+	out, err = ts.run("config concurrency 5")
+	assert.NoError(t, err)
+	assert.Equal(t, "concurrency: 5", out)
 }


### PR DESCRIPTION
This a PR to add support for concurrent re-encryption. 
Unfortunately, I discovered only once I had it all working that when using GPG2, gpg-agent is blocking and does not support concurrent access to its secring. This means that it does not constitute the significant speed-up one could hope for. (If a too big value is used in the setting it might even slow down the process.)

With GPG1, I tried it on a dummy store with 86 small secrets and it went down from:
```
time ./gopass recipients rm -store "<root>"   0xDA0BDE9DB49B2F71
87% cpu 4.382 total
```
to a mere 
```
time ./gopass recipients rm -store "<root>" 0xDA0BDE9DB49B2F71
329% cpu 1.816 total
```

If you plan to use Go's OpenPGP later on, I still think this is a worthy PR, since it would then allow to fully exploit all cores when re-encrypting. BTW, notice that if you plan to use Go's OpenPGP, you should still keep a fall-back to gpg since it does not support smartcards, while gpg does.