### PR TITLE
Add documentation about entropy

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,6 +89,8 @@ fpm:
   dependencies:
     - git
     - gnupg
+  recommends:
+    - rng-tools
 source:
   name_template: "{{.Binary}}-{{.Version}}"
   excludes:

--- a/docs/entropy.md
+++ b/docs/entropy.md
@@ -1,0 +1,41 @@
+# Entropy
+
+Generating cryptographic keys needs a lot of entropy. Especially `gnupg --gen-key`
+depletes the kernel entropy pool (`/dev/random`) quite fast and may apear to be
+stuck when it's waiting for new entropy.
+
+If you wonder how to speed this up consider installing `rng-tools`
+if this is available on your platform.
+
+After installing `rng-tools` please make sure `rngd` is actually running and
+replenishing your entropy pool.
+
+You can do so by keeping a watch on your available entropy and running an entropy
+consuming process like so.
+
+```
+watch -n1 cat /proc/sys/kernel/random/entropy_avail
+# switch to another terminal / screen
+cat /dev/random | rngtest -c 1000
+```
+
+The second command should complete within a few seconds and report no errors.
+If it takes much longer you probably don't have an hardware RNG and will have
+to generate some entropy by triggering some network activity and input.
+
+### Debian / Ubuntu
+
+```
+sudo apt-get install rng-tools
+```
+
+### CentOS / Fedora / RedHat
+
+```
+sudo yum install rng-tools
+```
+
+## Further Information
+
+* [RNG-Tools on the ArchLinux Wiki](https://wiki.archlinux.org/index.php/Rng-tools)
+* [gopass Issue #486](https://github.com/justwatchcom/gopass/issues/486)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -13,19 +13,22 @@
 
 gopass needs some external programs to work:
 
-* `gpg`
-* `git`
+* `gpg` - [GnuPG](https://www.gnupg.org/), preferably in Version 2 or later
+* `git` - [Git SCM](https://git-scm.com/), any Version should be OK
+
+It is recommended to have either `rng-tools` or `haveged` installed to speed up
+key generation if these are available for your platform.
 
 #### Ubuntu & Debian
 
 ```bash
-apt-get install gnupg git
+apt-get install gnupg git rng-tools
 ```
 
 #### RHEL & CentOS
 
 ```bash
-yum install gnupg2 git
+yum install gnupg2 git rng-tools
 ```
 
 #### macOS


### PR DESCRIPTION
This commit adds some warning before gpg key generation,
documentation around entropy as well as a recommendation on rng-tools
to the generated deb packages.

Fixes #486