### PR TITLE
Support reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ EXECUTABLE := gopass
 PWD := $(shell pwd)
 VERSION := $(shell cat VERSION)
 SHA := $(shell cat COMMIT 2>/dev/null || git rev-parse --short=8 HEAD)
-DATE := $(shell date -u '+%FT%T%z')
+
+# Support reproducible builds by embedding date according to SOURCE_DATE_EPOCH if present
+DATE := $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" '+%FT%T%z' 2>/dev/null || date -u '+%FT%T%z')
 
 GOLDFLAGS += -X "main.version=$(VERSION)"
 GOLDFLAGS += -X "main.date=$(DATE)"


### PR DESCRIPTION
Currently packaging gopass for Arch Linux into our repositories, and noticed there is an embedded build time that gets added. To get gopass reproducible it needs to adhere to `SOURCE_DATE_EPOCH` as documented by the reproducible builds project; https://reproducible-builds.org/docs/timestamps/

This patch adds the needed changes to the Makefile to achieve this. The logs below shows gopass built twice with the supplied patch.

```
λ fox@hackbook gopass » stat build1/gopass-1.6.2-1-x86_64.pkg.tar.xz
  File: build1/gopass-1.6.2-1-x86_64.pkg.tar.xz
  Size: 2870768   	Blocks: 5608       IO Block: 4096   regular file
Device: 17h/23d	Inode: 22830789    Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/     fox)   Gid: ( 1000/     fox)
Access: 2017-12-07 00:46:03.021118052 +0100
Modify: 2017-12-07 00:45:24.557331147 +0100
Change: 2017-12-07 00:45:24.693999423 +0100
 Birth: -
λ fox@hackbook gopass » stat build2/gopass-1.6.2-1-x86_64.pkg.tar.xz
  File: build2/gopass-1.6.2-1-x86_64.pkg.tar.xz
  Size: 2870768   	Blocks: 5608       IO Block: 4096   regular file
Device: 17h/23d	Inode: 22831712    Links: 1
Access: (0644/-rw-r--r--)  Uid: ( 1000/     fox)   Gid: ( 1000/     fox)
Access: 2017-12-07 00:47:26.365437312 +0100
Modify: 2017-12-07 00:46:02.797782082 +0100
Change: 2017-12-07 00:46:02.944450480 +0100
 Birth: -
λ fox@hackbook gopass » sha256sum build1/* build2/*
1ce072496c232de8857ef0b1acfbe150720cd513ae0b7cf80970a2d137af3886  build1/gopass-1.6.2-1-x86_64.pkg.tar.xz
1ce072496c232de8857ef0b1acfbe150720cd513ae0b7cf80970a2d137af3886  build2/gopass-1.6.2-1-x86_64.pkg.tar.xz
```
Build logs from a WIP tool: http://ix.io/CRr