### PR TITLE
Fix typo in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ go build
 ./gopass
 
 # run unit and meta tests
-make tests
+make test
 
 # run integration tests
 make test-integration


### PR DESCRIPTION
If I'm not wrong again, `make tests` should be `make test`