### PR TITLE
fix/some tests on mac

### DIFF
--- a/action/action_test.go
+++ b/action/action_test.go
@@ -88,8 +88,14 @@ func TestAction(t *testing.T) {
 		t.Fatalf("Error: %s", err)
 	}
 
-	if as := act.String(); as != "Store(Path: "+filepath.Join(td, "store")+", Mounts: )" {
-		t.Errorf("act.String(): %s", as)
+	if as := act.Name; as != "action.test" {
+		t.Errorf("act.Name: %s", as)
+	}
+	if as := act.Store.Path(); strings.Index(as, filepath.Join(td, "store")) == -1 {
+		t.Errorf("act.Store.Path(): %s", as)
+	}
+	if as := len(act.Store.Mounts()); as != 0 {
+		t.Errorf("len(act.Store.Mounts()) != 0, is: %d", as)
 	}
 	if !act.HasGPG() {
 		t.Errorf("no gpg")

--- a/action/edit_test.go
+++ b/action/edit_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/justwatchcom/gopass/utils/out"
 	"github.com/urfave/cli"
+	"os/exec"
 )
 
 func TestEdit(t *testing.T) {
@@ -57,7 +58,12 @@ func TestEditor(t *testing.T) {
 	}
 
 	want := "foobar"
-	out, err := act.editor(ctx, "/bin/touch", []byte(want))
+	touch, err := exec.LookPath("touch")
+	if (err != nil){
+		t.Errorf("Couldnt find touch. Error: %s", err)
+	}
+	
+	out, err := act.editor(ctx, touch, []byte(want))
 	if err != nil {
 		t.Errorf("Error: %s", err)
 	}


### PR DESCRIPTION
gets a lot more tests working on mac, but not 100%


there are still some wierndesses with paths in tests, for example theres a "ErrSneaky" happening in store tests, i printed around read.go and write.go and ran in both docker and local and got:

```
fmt.Printf("sneaky path on read?\n %s\n %s\n", p, s.path)
f !strings.HasPrefix(p, s.path) {
...
```

in docker
```
/tmp/gopass-015499290/foo.gpg
/tmp/gopass-015499290
```

in local
```
/private/var/folders/fq/88mmrq7n2154xp8xh9yq7y39tx12kl/T/gopass-832593809/foo.gpg
/var/folders/fq/88mmrq7n2154xp8xh9yq7y39tx12kl/T/gopass-832593809
```

i'm not sure where this `private` is coming from, perhaps some unix related path lib...