### PR TITLE
Add create message for jsonapi and corresponding test

### DIFF
--- a/docs/jsonapi.md
+++ b/docs/jsonapi.md
@@ -72,6 +72,30 @@ Similar to `query` but cuts host names and sub domains from the left side until 
 }
 ```
 
+### `create`
+
+#### Query:
+
+```json
+{
+   "type": "create",
+   "login": "myusername",
+   "password": "",
+   "length": 12,
+   "generate": true,
+   "use_symbols": true
+}
+```
+
+#### Response:
+
+```json
+{
+   "username": "myusername",
+   "password": "5^dX9j1\"b5^q"
+}
+```
+
 ## Error Response
 
 If an uncaught error occurs, the stringified error message is send back as response:

--- a/utils/jsonapi/messages.go
+++ b/utils/jsonapi/messages.go
@@ -30,6 +30,15 @@ type loginResponse struct {
 	Password string `json:"password"`
 }
 
+type createEntryMessage struct {
+	Name           string `json:"entry_name"`
+	Login          string `json:"login"`
+	Password       string `json:"password"`
+	PasswordLength int    `json:"length"`
+	Generate       bool   `json:"generate"`
+	UseSymbols     bool   `json:"use_symbols"`
+}
+
 type errorResponse struct {
 	Error string `json:"error"`
 }


### PR DESCRIPTION
I've added a message and corresponding implementation for generating / storing secrets via json message. This would allow simple password creation / storage from the browser.