### PR TITLE
Ksh completion

### DIFF
--- a/action/completion.go
+++ b/action/completion.go
@@ -37,8 +37,8 @@ func (s *Action) Complete(*cli.Context) {
 // CompletionKsh returns an OpenBSD ksh script used for auto completion
 func (s *Action) CompletionKsh(c *cli.Context, a *cli.App) error {
 	out := `
-	PASS_LIST=$(gopass ls -f)
-	set -A complete_gopass -- $PASS_LIST %s
+PASS_LIST=$(gopass ls -f)
+set -A complete_gopass -- $PASS_LIST %s
 `
 	var opts []string
 	for _, opt := range a.Commands {

--- a/action/completion.go
+++ b/action/completion.go
@@ -42,7 +42,7 @@ set -A complete_gopass -- $PASS_LIST %s
 `
 
 	if a == nil {
-		return nil
+		return fmt.Errorf("Can't parse command options")
 	}
 
 	var opts []string

--- a/action/completion.go
+++ b/action/completion.go
@@ -3,6 +3,7 @@ package action
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	fishcomp "github.com/justwatchcom/gopass/utils/completion/fish"
 	zshcomp "github.com/justwatchcom/gopass/utils/completion/zsh"
@@ -31,6 +32,25 @@ func (s *Action) Complete(*cli.Context) {
 	for _, v := range list {
 		fmt.Println(bashEscape(v))
 	}
+}
+
+// CompletionKsh returns an OpenBSD ksh script used for auto completion
+func (s *Action) CompletionKsh(c *cli.Context, a *cli.App) error {
+	out := `
+	PASS_LIST=$(gopass ls -f)
+	set -A complete_gopass -- $PASS_LIST %s
+`
+	var opts []string
+	for _, opt := range a.Commands {
+		opts = append(opts, opt.Name)
+		if len(opt.Aliases) > 0 {
+			opts = append(opts, strings.Join(opt.Aliases, " "))
+		}
+	}
+
+	fmt.Println(fmt.Sprintf(out, strings.Join(opts, " ")))
+
+	return nil
 }
 
 // CompletionBash returns a bash script used for auto completion

--- a/action/completion.go
+++ b/action/completion.go
@@ -34,8 +34,8 @@ func (s *Action) Complete(*cli.Context) {
 	}
 }
 
-// CompletionKsh returns an OpenBSD ksh script used for auto completion
-func (s *Action) CompletionKsh(c *cli.Context, a *cli.App) error {
+// CompletionOpenBSDKsh returns an OpenBSD ksh script used for auto completion
+func (s *Action) CompletionOpenBSDKsh(c *cli.Context, a *cli.App) error {
 	out := `
 PASS_LIST=$(gopass ls -f)
 set -A complete_gopass -- $PASS_LIST %s

--- a/action/completion_test.go
+++ b/action/completion_test.go
@@ -63,9 +63,9 @@ func TestComplete(t *testing.T) {
 		t.Errorf("should contain name of test")
 	}
 
-	// ksh
+	// openbsdksh
 	out = capture(t, func() error {
-		return act.CompletionKsh(nil, app)
+		return act.CompletionOpenBSDKsh(nil, app)
 	})
 	if !strings.Contains(out, "complete_gopass") {
 		t.Errorf("should contain name of test")

--- a/action/completion_test.go
+++ b/action/completion_test.go
@@ -62,4 +62,12 @@ func TestComplete(t *testing.T) {
 	if !strings.Contains(out, "action.test") {
 		t.Errorf("should contain name of test")
 	}
+
+	// ksh
+	out = capture(t, func() error {
+		return act.CompletionKsh(nil, app)
+	})
+	if !strings.Contains(out, "complete_gopass") {
+		t.Errorf("should contain name of test")
+	}
 }

--- a/main.go
+++ b/main.go
@@ -307,10 +307,10 @@ func main() {
 					return action.CompletionFish(c, app)
 				},
 			}, {
-				Name:  "ksh",
-				Usage: "Source for auto completion in ksh",
+				Name:  "openbsdksh",
+				Usage: "Source for auto completion in OpenBSD's ksh",
 				Action: func(c *cli.Context) error {
-					return action.CompletionKsh(c, app)
+					return action.CompletionOpenBSDKsh(c, app)
 				},
 			}},
 		},

--- a/main.go
+++ b/main.go
@@ -306,6 +306,12 @@ func main() {
 				Action: func(c *cli.Context) error {
 					return action.CompletionFish(c, app)
 				},
+			}, {
+				Name:  "ksh",
+				Usage: "Source for auto completion in ksh",
+				Action: func(c *cli.Context) error {
+					return action.CompletionKsh(c, app)
+				},
 			}},
 		},
 		{


### PR DESCRIPTION
This adds support for outputting completion for OpenBSD's ksh. I am a bit hesitant to keep the current name.. as other ksh implementations don't have completion.. so it might be better to make it "openbsdksh" or "oksh".. Wanted to get everyone's opinion on that one.. 