### PR TITLE
Add a note about cloning to a new recipient

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -79,6 +79,8 @@ gopass clone git@example.com/pass-work.git work # This will initialize the passw
 
 Please note that all cloned repositories must already have been initialized with gopass. (See the previous section for more details.)
 
+Note too that unless you are already a recipient of the cloned repository, you must add a the destination's public GPG key as a recipient to the existing store.
+
 ### Adding Secrets
 
 Let's say you want to create an account.


### PR DESCRIPTION
This note means to clarify the requirements for setting up a new recipient by cloning an existing store.

Fixes #630 

Please let me know if you'd like me to add further details, and thanks!