### PR TITLE
Remove blank line after "Copied <secret> to clipboard..." message.

### DIFF
--- a/action/clipboard.go
+++ b/action/clipboard.go
@@ -28,6 +28,6 @@ func copyToClipboard(ctx context.Context, name string, content []byte) error {
 		return errors.Wrapf(err, "failed to clear clipboard")
 	}
 
-	out.Print(ctx, "Copied %s to clipboard. Will clear in %d seconds.\n", color.YellowString(name), ctxutil.GetClipTimeout(ctx))
+	out.Print(ctx, "Copied %s to clipboard. Will clear in %d seconds.", color.YellowString(name), ctxutil.GetClipTimeout(ctx))
 	return nil
 }


### PR DESCRIPTION
Currently there's an extra blank line printed after the "Copied <secret> to clipboard. Will clear in <x> seconds." message. This PR removes that blank line.