### PR TITLE
Support HIBPv2 Dumps and API

### DIFF
--- a/action/hibp_test.go
+++ b/action/hibp_test.go
@@ -2,11 +2,16 @@ package action
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"flag"
+	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/justwatchcom/gopass/tests/gptest"
@@ -17,17 +22,17 @@ import (
 )
 
 const testHibpSample = `000000005AD76BD555C1D6D771DE417A4B87E4B4
-00000000A8DAE4228F821FB418F59826079BF368
-00000000DD7F2A1C68A35673713783CA390C9E93
-00000001E225B908BAC31C56DB04D892E47536E0
-00000008CD1806EB7B9B46A8F87690B2AC16F617
-0000000A0E3B9F25FF41DE4B5AC238C2D545C7A8
-0000000A1D4B746FAA3FD526FF6D5BC8052FDB38
-0000000CAEF405439D57847A8657218C618160B2
-0000000FC1C08E6454BED24F463EA2129E254D43
+00000000A8DAE4228F821FB418F59826079BF368:42
+00000000DD7F2A1C68A35673713783CA390C9E93:42
+00000001E225B908BAC31C56DB04D892E47536E0:42
+00000008CD1806EB7B9B46A8F87690B2AC16F617:42
+0000000A0E3B9F25FF41DE4B5AC238C2D545C7A8:42
+0000000A1D4B746FAA3FD526FF6D5BC8052FDB38:42
+0000000CAEF405439D57847A8657218C618160B2:42
+0000000FC1C08E6454BED24F463EA2129E254D43:42
 00000010F4B38525354491E099EB1796278544B1`
 
-func TestHIBP(t *testing.T) {
+func TestHIBPDump(t *testing.T) {
 	u := gptest.NewUnitTester(t)
 	defer u.Remove()
 
@@ -56,5 +61,86 @@ func TestHIBP(t *testing.T) {
 	assert.NoError(t, ioutil.WriteFile(fn, []byte(testHibpSample), 0644))
 	assert.NoError(t, os.Setenv("HIBP_DUMPS", fn))
 	assert.NoError(t, act.HIBP(ctx, c))
+	buf.Reset()
+
+	// gzip
+	fn = filepath.Join(u.Dir, "dump.txt.gz")
+	assert.NoError(t, testWriteGZ(fn, []byte(testHibpSample)))
+	assert.NoError(t, os.Setenv("HIBP_DUMPS", fn))
+	assert.NoError(t, act.HIBP(ctx, c))
+	buf.Reset()
+}
+
+func testWriteGZ(fn string, buf []byte) error {
+	fh, err := os.OpenFile(fn, os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = fh.Close()
+	}()
+
+	gzw := gzip.NewWriter(fh)
+	defer func() {
+		_ = gzw.Close()
+	}()
+
+	_, err = gzw.Write(buf)
+	return err
+}
+
+func TestHIBPAPI(t *testing.T) {
+	u := gptest.NewUnitTester(t)
+	defer u.Remove()
+
+	ctx := context.Background()
+	ctx = ctxutil.WithAlwaysYes(ctx, true)
+	ctx = out.WithHidden(ctx, true)
+	act, err := newMock(ctx, u)
+	assert.NoError(t, err)
+
+	buf := &bytes.Buffer{}
+	out.Stdout = buf
+	defer func() {
+		out.Stdout = os.Stdout
+	}()
+
+	app := cli.NewApp()
+	fs := flag.NewFlagSet("default", flag.ContinueOnError)
+	bf := cli.BoolFlag{
+		Name:  "api",
+		Usage: "api",
+	}
+	assert.NoError(t, bf.ApplyWithError(fs))
+	assert.NoError(t, fs.Parse([]string{"--api=true"}))
+	c := cli.NewContext(app, fs, nil)
+
+	reqCnt := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqCnt++
+		if reqCnt < 2 {
+			http.Error(w, "fake error", http.StatusInternalServerError)
+			return
+		}
+		if strings.TrimPrefix(r.URL.String(), "/range/") == "8843D" {
+			fmt.Fprintf(w, "8843D:1\n")                                     // invalid
+			fmt.Fprintf(w, "7F92416211DE9EBB963FF4CE2812593287:3234879\n")  // invalid
+			fmt.Fprintf(w, "7F92416211DE9EBB963FF4CE28125932878:\n")        // invalid
+			fmt.Fprintf(w, "7F92416211DE9EBB963FF4CE28125932878\n")         // invalid
+			fmt.Fprintf(w, "7F92416211DE9EBB963FF4CE28125932878:3234879\n") // valid
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+	hibpAPIURL = ts.URL
+
+	// test with one entry
+	assert.NoError(t, act.HIBP(ctx, c))
+	buf.Reset()
+
+	// add another one
+	assert.NoError(t, act.insertStdin(ctx, "baz", []byte("foobar")))
+	assert.Error(t, act.HIBP(ctx, c))
 	buf.Reset()
 }

--- a/commands.go
+++ b/commands.go
@@ -68,11 +68,12 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 			Subcommands: []cli.Command{
 				{
 					Name:  "hibp",
-					Usage: "Detect leaked passwords (ALPHA)",
+					Usage: "Detect leaked passwords",
 					Description: "" +
 						"This command will decrypt all secrets and check the passwords against the public " +
-						"havibeenpwned.com dumps. " +
-						"To use this feature you need to download the dumps from https://haveibeenpwned.com/passwords first. This is a very expensive operation for advanced users",
+						"havibeenpwned.com v2 API or Dumps. " +
+						"To use the dumps you need to download the dumps from https://haveibeenpwned.com/passwords first. This is a very expensive operation for advanced users." +
+						"Most users should probably use the API.",
 					Before: func(c *cli.Context) error { return action.Initialized(withGlobalFlags(ctx, c), c) },
 					Action: func(c *cli.Context) error {
 						return action.HIBP(withGlobalFlags(ctx, c), c)
@@ -81,6 +82,10 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 						cli.BoolFlag{
 							Name:  "force, f",
 							Usage: "Force to move the secret and overwrite existing one",
+						},
+						cli.BoolFlag{
+							Name:  "api, a",
+							Usage: "Use HIBP API",
 						},
 					},
 				},


### PR DESCRIPTION
This commit implements support for the HIBPv2 Dumps and API.
See https://www.troyhunt.com/ive-just-launched-pwned-passwords-version-2/
Since the new dumps aren't sorted by SHA anymore using them requires some expensive preprocessing. But since it's a very expensive operation anyway, only intended to be performed very very few users, this should be OK.

As a much easier approach this PR also includes a way to securely check the password hashes against the HIBPv2 API. To avoid leaking sensitive data (SHA1 hashes of secrets) the API supports sending only the first five chars of the hash and returns a list of possible matches which we then check on the client side. Of course this still leaks some entropy to the server, but I can't imagine any feasible attack using only the first five bytes of the hash.