### PR TITLE
Auto copy with safecontent

### DIFF
--- a/action/show.go
+++ b/action/show.go
@@ -101,7 +101,8 @@ func (s *Action) showHandleOutput(ctx context.Context, name, key string, sec *se
 		case ctxutil.IsShowSafeContent(ctx) && !IsForce(ctx):
 			content = sec.Body()
 			if content == "" {
-				return exitError(ctx, ExitNotFound, store.ErrNoBody, "no safe content to display, you can force display with show -f")
+				color.Yellow("No safe content to display, you can force display with show -f.\nCopying password instead.")
+				return copyToClipboard(ctx, name, []byte(sec.Password()))
 			}
 		default:
 			buf, err := sec.Bytes()

--- a/action/show.go
+++ b/action/show.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/store"
 	"github.com/justwatchcom/gopass/store/secret"
 	"github.com/justwatchcom/gopass/utils/ctxutil"
@@ -101,7 +100,7 @@ func (s *Action) showHandleOutput(ctx context.Context, name, key string, sec *se
 		case ctxutil.IsShowSafeContent(ctx) && !IsForce(ctx):
 			content = sec.Body()
 			if content == "" {
-				color.Yellow("No safe content to display, you can force display with show -f.\nCopying password instead.")
+				out.Yellow(ctx, "No safe content to display, you can force display with show -f.\nCopying password instead.")
 				return copyToClipboard(ctx, name, []byte(sec.Password()))
 			}
 		default:
@@ -122,7 +121,7 @@ func (s *Action) showHandleError(ctx context.Context, c *cli.Context, name strin
 	if err != store.ErrNotFound || !recurse || !ctxutil.IsTerminal(ctx) {
 		return exitError(ctx, ExitUnknown, err, "failed to retrieve secret '%s': %s", name, err)
 	}
-	color.Yellow("Entry '%s' not found. Starting search...", name)
+	out.Yellow(ctx, "Entry '%s' not found. Starting search...", name)
 	if err := s.Find(ctx, c); err != nil {
 		return exitError(ctx, ExitNotFound, err, "%s", err)
 	}

--- a/store/err.go
+++ b/store/err.go
@@ -21,8 +21,6 @@ var (
 	ErrGitNoRemote = errors.Errorf("git has no remote origin")
 	// ErrGitNothingToCommit is returned if there are no staged changes
 	ErrGitNothingToCommit = errors.Errorf("git has nothing to commit")
-	// ErrNoBody is returned if a secret exists but has no content beyond a password
-	ErrNoBody = errors.Errorf("no safe content to display, you can force display with show -f")
 	// ErrNoPassword is returned is a secret exists but has no password, only a body
 	ErrNoPassword = errors.Errorf("no password to display")
 	// ErrYAMLNoMark is returned if a secret contains no valid YAML document marker

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -34,7 +34,7 @@ func TestShow(t *testing.T) {
 	assert.NoError(t, err)
 
 	out, _ = ts.run("show fixed/secret")
-	assert.Equal(t, "\nError: no safe content to display, you can force display with show -f\n", out)
+	assert.Contains(t, out, "No safe content to display, you can force display with show -f.\nCopying password instead.")
 
 	out, err = ts.run("show -f fixed/secret")
 	assert.NoError(t, err)
@@ -47,6 +47,10 @@ func TestShow(t *testing.T) {
 	out, err = ts.run("show fixed/twoliner -f")
 	assert.NoError(t, err)
 	assert.Equal(t, "and\nmore stuff", out)
+
+	out, err = ts.run("show fixed/twoliner -c")
+	assert.NoError(t, err)
+	assert.NotContains(t, out, "No safe content to display, you can force display with show -f")
 
 	_, err = ts.run("config safecontent false")
 	assert.NoError(t, err)


### PR DESCRIPTION
With this, passwords will be copied to clipboard when safecontent is set and there is only a password in the entry invoked.
This is addressing #684.

I've adapted the unit tests accordingly and I've added a unit test to check for conflict between safecontent and -c in the show action. (To avoid regressions later on, as the expected behaviour when specifying -c is to copy to clipboard, not to show the (safe) content)