### PR TITLE
fixes missing bash binary

### DIFF
--- a/action/update_others.go
+++ b/action/update_others.go
@@ -67,7 +67,7 @@ func (s *Action) updateGopass(ctx context.Context, version string, urlStr string
 
 	// launch rename script and exit
 	out.Yellow(ctx, "Downloaded update. Exiting to install in place (%s) ...", exe)
-	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf(`sleep 1; echo ""; echo -n "Please wait ... "; sleep 2; mv "%s" "%s" && echo OK`, binDst, exe))
+	cmd := exec.Command("/bin/sh", "-c", fmt.Sprintf(`sleep 1; echo ""; echo -n "Please wait ... "; sleep 2; mv "%s" "%s" && echo OK`, binDst, exe))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/utils/jsonapi/manifest/constants.go
+++ b/utils/jsonapi/manifest/constants.go
@@ -1,6 +1,6 @@
 package manifest
 
-var wrapperTemplate = `#!/bin/bash
+var wrapperTemplate = `#!/bin/sh
 
 if [ -f ~/.gpg-agent-info ] && [ -n "$(pgrep gpg-agent)" ]; then
 source ~/.gpg-agent-info


### PR DESCRIPTION
On some systems /bin/bash might not exist (ie nixos) or point to non-default shell (ie. macos) hence it should be picked from environment. Thus the change.