### PR TITLE
 Fixes #667 and correct a few details 

### DIFF
--- a/action/config_test.go
+++ b/action/config_test.go
@@ -39,6 +39,7 @@ func TestConfig(t *testing.T) {
 	assert.NoError(t, act.Config(ctx, c))
 	want := `root store config:
   askformore: false
+  autoclip: true
   autoimport: true
   autosync: true
   cliptimeout: 45
@@ -76,6 +77,7 @@ foo/nopager: false`
 	act.printConfigValues(ctx, "")
 	want = `root store config:
   askformore: false
+  autoclip: true
   autoimport: true
   autosync: true
   cliptimeout: 45
@@ -88,6 +90,7 @@ foo/nopager: false`
 	want += `  safecontent: false
   usesymbols: false
 mount 'foo' config:
+  autoclip: false
   autoimport: false
   autosync: false
   cliptimeout: 23
@@ -120,6 +123,7 @@ mount 'foo' config:
 	// action.ConfigComplete
 	act.ConfigComplete(c)
 	want = `askformore
+autoclip
 autoimport
 autosync
 cliptimeout

--- a/action/generate.go
+++ b/action/generate.go
@@ -100,7 +100,7 @@ func (s *Action) generateCopyOrPrint(ctx context.Context, c *cli.Context, name, 
 		)
 		return nil
 	}
-	if ctxutil.IsAutoClip(ctx) {
+	if ctxutil.IsAutoClip(ctx) || c.Bool("clip") {
 		if err := copyToClipboard(ctx, name, []byte(password)); err != nil {
 			return exitError(ctx, ExitIO, err, "failed to copy to clipboard: %s", err)
 		}

--- a/action/generate.go
+++ b/action/generate.go
@@ -100,9 +100,10 @@ func (s *Action) generateCopyOrPrint(ctx context.Context, c *cli.Context, name, 
 		)
 		return nil
 	}
-
-	if err := copyToClipboard(ctx, name, []byte(password)); err != nil {
-		return exitError(ctx, ExitIO, err, "failed to copy to clipboard: %s", err)
+	if ctxutil.IsAutoClip(ctx) {
+		if err := copyToClipboard(ctx, name, []byte(password)); err != nil {
+			return exitError(ctx, ExitIO, err, "failed to copy to clipboard: %s", err)
+		}
 	}
 	return nil
 }

--- a/action/generate.go
+++ b/action/generate.go
@@ -203,7 +203,9 @@ func (s *Action) generateSetPassword(ctx context.Context, name, key, password st
 	}
 
 	// generate a completely new secret
-	if err := s.Store.Set(sub.WithReason(ctx, "Generated Password"), name, secret.New(password, "")); err != nil {
+	var err error
+	ctx, err = s.Store.SetContext(sub.WithReason(ctx, "Generated Password"), name, secret.New(password, ""))
+	if err != nil {
 		return ctx, exitError(ctx, ExitEncrypt, err, "failed to create '%s': %s", name, err)
 	}
 	return ctx, nil

--- a/action/show.go
+++ b/action/show.go
@@ -100,8 +100,11 @@ func (s *Action) showHandleOutput(ctx context.Context, name, key string, sec *se
 		case ctxutil.IsShowSafeContent(ctx) && !IsForce(ctx):
 			content = sec.Body()
 			if content == "" {
-				out.Yellow(ctx, "No safe content to display, you can force display with show -f.\nCopying password instead.")
-				return copyToClipboard(ctx, name, []byte(sec.Password()))
+				if ctxutil.IsAutoClip(ctx) {
+					out.Yellow(ctx, "No safe content to display, you can force display with show -f.\nCopying password instead.")
+					return copyToClipboard(ctx, name, []byte(sec.Password()))
+				}
+				return exitError(ctx, ExitNotFound, store.ErrNoBody, store.ErrNoBody.Error())
 			}
 		default:
 			buf, err := sec.Bytes()

--- a/commands.go
+++ b/commands.go
@@ -360,6 +360,10 @@ func getCommands(ctx context.Context, action *ap.Action, app *cli.App) []cli.Com
 			BashComplete: func(c *cli.Context) { action.Complete(ctx, c) },
 			Flags: []cli.Flag{
 				cli.BoolFlag{
+					Name:  "clip, c",
+					Usage: "Copy the generated password to the clipboard",
+				},
+				cli.BoolFlag{
 					Name:  "print, p",
 					Usage: "Print the generated password to the terminal",
 				},

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ func New() *Config {
 	return &Config{
 		Root: &StoreConfig{
 			AskForMore:    false,
+			AutoClip:      true,
 			AutoImport:    true,
 			AutoSync:      true,
 			ClipTimeout:   45,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ func TestNewConfig(t *testing.T) {
 	assert.Equal(t, backend.GPGCLI, cfg.Root.Path.Crypto)
 	assert.Equal(t, backend.GitCLI, cfg.Root.Path.RCS)
 	assert.Equal(t, backend.FS, cfg.Root.Path.Storage)
-	assert.Equal(t, "Config[Root:StoreConfig[AskForMore:false,AutoImport:true,AutoSync:true,ClipTimeout:45,NoColor:false,NoConfirm:false,NoPager:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false],Mounts(),Version:]", cfg.String())
+	assert.Equal(t, "Config[Root:StoreConfig[AskForMore:false,AutoClip:true,AutoImport:true,AutoSync:true,ClipTimeout:45,NoColor:false,NoConfirm:false,NoPager:false,Notifications:true,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false],Mounts(),Version:]", cfg.String())
 
 	cfg = nil
 	assert.Error(t, cfg.checkDefaults())
@@ -33,7 +33,7 @@ func TestNewConfig(t *testing.T) {
 	cfg.Mounts["foo"] = &StoreConfig{}
 	cfg.Mounts["bar"] = &StoreConfig{}
 	assert.NoError(t, cfg.checkDefaults())
-	assert.Equal(t, "Config[Root:StoreConfig[AskForMore:false,AutoImport:false,AutoSync:false,ClipTimeout:0,NoColor:false,NoConfirm:false,NoPager:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false],Mounts(bar=>StoreConfig[AskForMore:false,AutoImport:false,AutoSync:false,ClipTimeout:0,NoColor:false,NoConfirm:false,NoPager:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false]foo=>StoreConfig[AskForMore:false,AutoImport:false,AutoSync:false,ClipTimeout:0,NoColor:false,NoConfirm:false,NoPager:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false]),Version:]", cfg.String())
+	assert.Equal(t, "Config[Root:StoreConfig[AskForMore:false,AutoClip:false,AutoImport:false,AutoSync:false,ClipTimeout:0,NoColor:false,NoConfirm:false,NoPager:false,Notifications:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false],Mounts(bar=>StoreConfig[AskForMore:false,AutoClip:false,AutoImport:false,AutoSync:false,ClipTimeout:0,NoColor:false,NoConfirm:false,NoPager:false,Notifications:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false]foo=>StoreConfig[AskForMore:false,AutoClip:false,AutoImport:false,AutoSync:false,ClipTimeout:0,NoColor:false,NoConfirm:false,NoPager:false,Notifications:false,Path:gpgcli-gitcli-fs+file:,SafeContent:false,UseSymbols:false]),Version:]", cfg.String())
 }
 
 func TestSetConfigValue(t *testing.T) {

--- a/config/context.go
+++ b/config/context.go
@@ -28,5 +28,8 @@ func (c StoreConfig) WithContext(ctx context.Context) context.Context {
 	if !ctxutil.HasShowSafeContent(ctx) {
 		ctx = ctxutil.WithShowSafeContent(ctx, c.SafeContent)
 	}
+	if !ctxutil.HasAutoClip(ctx) {
+		ctx = ctxutil.WithAutoClip(ctx, c.AutoClip)
+	}
 	return ctx
 }

--- a/config/store_config.go
+++ b/config/store_config.go
@@ -13,6 +13,7 @@ import (
 // StoreConfig is a per-store (root or mount) config
 type StoreConfig struct {
 	AskForMore    bool         `yaml:"askformore"`    // ask for more data on generate
+	AutoClip      bool         `yaml:"autoclip"`      // decide whether passwords are automatically copied or not
 	AutoImport    bool         `yaml:"autoimport"`    // import missing public keys w/o asking
 	AutoSync      bool         `yaml:"autosync"`      // push to git remote after commit, pull before push if necessary
 	ClipTimeout   int          `yaml:"cliptimeout"`   // clear clipboard after seconds
@@ -109,5 +110,5 @@ func (c *StoreConfig) SetConfigValue(key, value string) error {
 }
 
 func (c *StoreConfig) String() string {
-	return fmt.Sprintf("StoreConfig[AskForMore:%t,AutoImport:%t,AutoSync:%t,ClipTimeout:%d,NoColor:%t,NoConfirm:%t,NoPager:%t,Path:%s,SafeContent:%t,UseSymbols:%t]", c.AskForMore, c.AutoImport, c.AutoSync, c.ClipTimeout, c.NoColor, c.NoConfirm, c.NoPager, c.Path, c.SafeContent, c.UseSymbols)
+	return fmt.Sprintf("StoreConfig[AskForMore:%t,AutoClip:%t,AutoImport:%t,AutoSync:%t,ClipTimeout:%d,NoColor:%t,NoConfirm:%t,NoPager:%t,Notifications:%t,Path:%s,SafeContent:%t,UseSymbols:%t]", c.AskForMore, c.AutoClip, c.AutoImport, c.AutoSync, c.ClipTimeout, c.NoColor, c.NoConfirm, c.NoPager, c.Notifications, c.Path, c.SafeContent, c.UseSymbols)
 }

--- a/docs/features.md
+++ b/docs/features.md
@@ -124,7 +124,9 @@ The generated password for golang.org/gopher is:
 Eech4ahRoy2oowi0ohl
 ```
 
-The `generate` command will ask for any missing arguments, like the name of the secret or the length. If you don't want the password to be displayed use the `-c` flag to copy it to your clipboard.
+The `generate` command will ask for any missing arguments, like the name of the secret or the length. By default the password is copied to clipboard. If you don't want the password to be copied, but displayed instead, use the `-p` flag to print it.
+
+By default the password is copied to clipboard, but you can disable this using the `AutoClip` option, which, when set to`false`, will neither display, nor print the password. This is overriden by the `-p` or `-c` flags.
 
 ### Edit a secret
 

--- a/store/err.go
+++ b/store/err.go
@@ -21,6 +21,8 @@ var (
 	ErrGitNoRemote = errors.Errorf("git has no remote origin")
 	// ErrGitNothingToCommit is returned if there are no staged changes
 	ErrGitNothingToCommit = errors.Errorf("git has nothing to commit")
+	// ErrNoBody is returned if a secret exists but has no content beyond a password
+	ErrNoBody = errors.Errorf("no safe content to display, you can force display with show -f")
 	// ErrNoPassword is returned is a secret exists but has no password, only a body
 	ErrNoPassword = errors.Errorf("no password to display")
 	// ErrYAMLNoMark is returned if a secret contains no valid YAML document marker

--- a/store/root/write.go
+++ b/store/root/write.go
@@ -11,3 +11,9 @@ func (r *Store) Set(ctx context.Context, name string, sec *secret.Secret) error 
 	ctx, store, name := r.getStore(ctx, name)
 	return store.Set(ctx, name, sec)
 }
+
+// SetContext encodes and write the ciphertext of one entry to disk and propagate the context
+func (r *Store) SetContext(ctx context.Context, name string, sec *secret.Secret) (context.Context, error) {
+	ctx, store, name := r.getStore(ctx, name)
+	return ctx, store.Set(ctx, name, sec)
+}

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -39,7 +39,7 @@ func TestShow(t *testing.T) {
 
 	_, err = ts.run("config autoclip false")
 	assert.NoError(t, err)
-	out, err = ts.run("show fixed/secret")
+	_, err = ts.run("show fixed/secret")
 	assert.Error(t, err)
 
 	out, err = ts.run("show -f fixed/secret")

--- a/tests/show_test.go
+++ b/tests/show_test.go
@@ -33,8 +33,14 @@ func TestShow(t *testing.T) {
 	_, err = ts.run("show foo -force")
 	assert.NoError(t, err)
 
-	out, _ = ts.run("show fixed/secret")
-	assert.Contains(t, out, "No safe content to display, you can force display with show -f.\nCopying password instead.")
+	out, err = ts.run("show fixed/secret")
+	assert.NoError(t, err)
+	assert.Contains(t, out, "safe content to display, you can force display with show -f.\nCopying password instead.")
+
+	_, err = ts.run("config autoclip false")
+	assert.NoError(t, err)
+	out, err = ts.run("show fixed/secret")
+	assert.Error(t, err)
 
 	out, err = ts.run("show -f fixed/secret")
 	assert.NoError(t, err)
@@ -50,7 +56,7 @@ func TestShow(t *testing.T) {
 
 	out, err = ts.run("show fixed/twoliner -c")
 	assert.NoError(t, err)
-	assert.NotContains(t, out, "No safe content to display, you can force display with show -f")
+	assert.NotContains(t, out, "safe content to display")
 
 	_, err = ts.run("config safecontent false")
 	assert.NoError(t, err)

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -23,6 +23,7 @@ import (
 const (
 	gopassConfig = `root:
   askformore: false
+  autoclip: true
   autoimport: true
   autosync: false
   cliptimeout: 45

--- a/utils/ctxutil/ctxutil.go
+++ b/utils/ctxutil/ctxutil.go
@@ -22,6 +22,7 @@ const (
 	ctxKeyFuzzySearch
 	ctxKeyVerbose
 	ctxNotifications
+	ctxKeyAutoClip
 )
 
 // WithDebug returns a context with an explizit value for debug
@@ -206,7 +207,7 @@ func IsNoPager(ctx context.Context) bool {
 	return bv
 }
 
-// WithShowSafeContent returns a context with the value for ask for more set
+// WithShowSafeContent returns a context with the value for ShowSafeContent set
 func WithShowSafeContent(ctx context.Context, bv bool) context.Context {
 	return context.WithValue(ctx, ctxKeyShowSafeContent, bv)
 }
@@ -217,7 +218,7 @@ func HasShowSafeContent(ctx context.Context) bool {
 	return ok
 }
 
-// IsShowSafeContent returns the value of ask for more or the default (false)
+// IsShowSafeContent returns the value of ShowSafeContent or the default (false)
 func IsShowSafeContent(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxKeyShowSafeContent).(bool)
 	if !ok {
@@ -360,6 +361,26 @@ func HasNotifications(ctx context.Context) bool {
 // IsNotifications returns the value of Notifications or the default (true)
 func IsNotifications(ctx context.Context) bool {
 	bv, ok := ctx.Value(ctxNotifications).(bool)
+	if !ok {
+		return true
+	}
+	return bv
+}
+
+// WithAutoClip returns a context with the value for AutoClip set
+func WithAutoClip(ctx context.Context, bv bool) context.Context {
+	return context.WithValue(ctx, ctxKeyAutoClip, bv)
+}
+
+// HasAutoClip returns true if a value for AutoClip has been set in this context
+func HasAutoClip(ctx context.Context) bool {
+	_, ok := ctx.Value(ctxKeyAutoClip).(bool)
+	return ok
+}
+
+// IsAutoClip returns the value of AutoClip or the default (true)
+func IsAutoClip(ctx context.Context) bool {
+	bv, ok := ctx.Value(ctxKeyAutoClip).(bool)
 	if !ok {
 		return true
 	}

--- a/utils/ctxutil/ctxutil.go
+++ b/utils/ctxutil/ctxutil.go
@@ -235,7 +235,7 @@ func WithGitCommit(ctx context.Context, bv bool) context.Context {
 
 // HasGitCommit returns true if a value for GitCommit has been set in this context
 func HasGitCommit(ctx context.Context) bool {
-	_, ok := ctx.Value(ctxKeyShowSafeContent).(bool)
+	_, ok := ctx.Value(ctxKeyGitCommit).(bool)
 	return ok
 }
 


### PR DESCRIPTION
This primarily adds the config option requested in #667.

I've added back the notion or erroring in case of a show action on an
entry with only a password and the safe content option enabled.

Also I've fixed the way the String() function of the StoreConfig forgot
to display the Notification value in its output.

I've also handled the merge conflict caused by  #703.

Now, this does NOT work for the generate action, for a reason I do not yet fully understand. I hope you'll be able to help me there.
In the show action, the context seems to correctly use the config values set. 

However, when running the Generate action, `ctxutil.HasAutoClip(ctx)` returns `false`, even if `gopass config autoclip` returns `true`.
As per the default value of AutoClip, `IsAutoClip` will return `true` is `HasAutoClip` is `false`...

This makes no sense to me, it's just like if the Generate action had not loaded the context correctly.