### PR TITLE
Bugfix for Secret.String() not adding a blank second line

### DIFF
--- a/pkg/store/secret/secret.go
+++ b/pkg/store/secret/secret.go
@@ -66,8 +66,12 @@ func (s *Secret) Bytes() ([]byte, error) {
 func (s *Secret) String() string {
 	var buf strings.Builder
 	_, _ = buf.WriteString(s.password)
-	_, _ = buf.WriteString("\n")
-	_, _ = buf.WriteString(s.body)
+
+	if s.body != "" {
+		_, _ = buf.WriteString("\n")
+		_, _ = buf.WriteString(s.body)
+	}
+
 	return buf.String()
 }
 

--- a/pkg/store/secret/secret_test.go
+++ b/pkg/store/secret/secret_test.go
@@ -109,6 +109,7 @@ func TestParse(t *testing.T) {
 		Out      []byte
 		Password string
 		Body     string
+		String   string
 		Data     map[string]interface{}
 		Fail     bool
 	}{
@@ -117,6 +118,8 @@ func TestParse(t *testing.T) {
 			In:       []byte(`password`),
 			Out:      []byte("password"),
 			Password: "password",
+			Body:     "",
+			String:   "password",
 		},
 		{
 			Desc: "Multiline secret",
@@ -207,6 +210,9 @@ key2: value2`,
 		assert.NoError(t, err)
 		if tc.Out != nil {
 			assert.Equal(t, string(tc.Out), string(b))
+		}
+		if tc.String != "" {
+			assert.Equal(t, tc.String, sec.String(), tc.Desc)
 		}
 	}
 }


### PR DESCRIPTION
Previously when having a secret containing only one line of text,
retrieving the entire secret contents with `.String()` appended
a blank empty second line.

These changes fixes that by checking if there in fact is more than one
line / `.Body()` exists before appending it.

The expected `.String()` output before applying a fix:

```
=== RUN   TestParse
--- FAIL: TestParse (0.00s)
    secret_test.go:215:
            Error Trace:    secret_test.go:215
            Error:          Not equal:
                            expected: "password"
                            actual  : "password\n"
            Test:           TestParse
            Messages:       Simple Secret
```

Does this sound reasonable?