### PR TITLE
Fix JSON API wrapper shebang

### DIFF
--- a/pkg/jsonapi/manifest/constants.go
+++ b/pkg/jsonapi/manifest/constants.go
@@ -1,6 +1,6 @@
 package manifest
 
-var wrapperTemplate = `#!/bin/sh
+var wrapperTemplate = `#!/usr/bin/env bash
 
 if [ -f ~/.gpg-agent-info ] && [ -n "$(pgrep gpg-agent)" ]; then
 source ~/.gpg-agent-info


### PR DESCRIPTION
It's bad practice to assume you know the path of anything when writing
a portable script. That's what `/usr/bin/env` is for.

Fix #744 