### PR TITLE
Initialize before completion

### DIFF
--- a/pkg/action/completion.go
+++ b/pkg/action/completion.go
@@ -25,6 +25,7 @@ func bashEscape(s string) string {
 
 // Complete prints a list of all password names to os.Stdout
 func (s *Action) Complete(ctx context.Context, c *cli.Context) {
+	s.Store.Initialized(ctx) // important to make sure the structs are not nil
 	list, err := s.Store.List(ctx, 0)
 	if err != nil {
 		return


### PR DESCRIPTION
This commit calls the initialization function before the
completion methods as well.

Fixes #746