### PR TITLE
Allow running native hosts messaging as default when binary is renamed

### DIFF
--- a/app.go
+++ b/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/blang/semver"
 	ap "github.com/justwatchcom/gopass/pkg/action"
@@ -57,6 +58,10 @@ func setupApp(ctx context.Context, sv semver.Version) *cli.App {
 	}
 
 	app.Action = func(c *cli.Context) error {
+		if strings.HasSuffix(os.Args[0], "native_host") || strings.HasSuffix(os.Args[0], "native_host.exe") {
+			return action.JSONAPI(withGlobalFlags(ctx, c), c)
+		}
+
 		if err := action.Initialized(withGlobalFlags(ctx, c), c); err != nil {
 			return err
 		}


### PR DESCRIPTION
This change uses `jsonapi listen` as default action if the binary is renamed / copied to gopass_native_host or gopass_native_host.exe . This makes gopass compatible with windows browsers, which require an executable and not a script to be called.

I would test this a bit with some windows users and add automated setup and / or documentation later on. Does that make sense?