### PR TITLE
Bail-out on q-key during initializing store

### DIFF
--- a/pkg/cui/recipients.go
+++ b/pkg/cui/recipients.go
@@ -213,6 +213,10 @@ func AskForPrivateKey(ctx context.Context, crypto backend.Crypto, name, prompt s
 		}
 		iv, err := termio.AskForInt(ctx, fmt.Sprintf("Please enter the number of a key (0-%d, [q]uit)", len(kl)-1), 0)
 		if err != nil {
+			if err.Error() == "user aborted" {
+				return "", err
+			}
+
 			continue
 		}
 		if iv >= 0 && iv < len(kl) {


### PR DESCRIPTION
During initializing store, on step where `gopass` requests ID of a private key, user cannot immediately stop the process, when he type a `q` letter (as a quit). 

Example output from console:

```console
[0] gpg - Piotr <piotr@gopass.localhost>
[1] gpg - Piotr <piotr@so.localhost>
[2] gpg - Piotr <piotr@awesome.localhost>
Please enter the number of a key (0-2, [q]uit) [0]: q
Please select a private key for encrypting secrets:
[0] gpg - Piotr <piotr@gopass.localhost>
[1] gpg - Piotr <piotr@so.localhost>
[2] gpg - Piotr <piotr@awesome.localhost>
Please enter the number of a key (0-2, [q]uit) [0]:
```