### PR TITLE
Fix typos in create command

### DIFF
--- a/pkg/action/create/create.go
+++ b/pkg/action/create/create.go
@@ -451,12 +451,12 @@ func (s *creator) createGeneric(ctx context.Context, c *cli.Context) error {
 
 // createGeneratePasssword will walk through the password generation steps
 func (s *creator) createGeneratePassword(ctx context.Context) (string, error) {
-	xkcd, err := termio.AskForBool(ctx, "Do you want an rememberable password?", true)
+	xkcd, err := termio.AskForBool(ctx, "Do you want a rememberable password?", true)
 	if err != nil {
 		return "", err
 	}
 	if xkcd {
-		length, err := termio.AskForInt(ctx, "How many words should be cominbed into a passphrase?", 4)
+		length, err := termio.AskForInt(ctx, "How many words should be combined into a passphrase?", 4)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Just started evaluating gopass as a password manager and noticed a few typos while watching the demo video. I don't know Go yet so this is all I can offer at the moment. Thanks for the hard work!

**Edit:** Not sure why Travis failed. I looked around for any tests that needed updating but didn't find any, and it looks like the [offending line](https://travis-ci.org/justwatchcom/gopass/builds/370638660#L591) is unrelated to this PR. Happy to help with whatever needs fixing.