### PR TITLE
Follow import ordering & grouping conventions

### DIFF
--- a/app.go
+++ b/app.go
@@ -5,12 +5,13 @@ import (
 	"os"
 	"strings"
 
-	"github.com/blang/semver"
 	ap "github.com/justwatchcom/gopass/pkg/action"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
+	"github.com/blang/semver"
 	"github.com/urfave/cli"
 )
 

--- a/commands.go
+++ b/commands.go
@@ -12,6 +12,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/agent/client"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
 	"github.com/urfave/cli"
 )
 

--- a/context.go
+++ b/context.go
@@ -5,12 +5,14 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/fatih/color"
+	"golang.org/x/crypto/ssh/terminal"
+
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/gpg"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
-	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/fatih/color"
 )
 
 func initContext(ctx context.Context, cfg *config.Config) context.Context {

--- a/main.go
+++ b/main.go
@@ -10,10 +10,11 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/blang/semver"
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/protect"
+
+	"github.com/blang/semver"
+	"github.com/fatih/color"
 	colorable "github.com/mattn/go-colorable"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -6,10 +6,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/root"
+
+	"github.com/blang/semver"
 )
 
 var (

--- a/pkg/action/action_test.go
+++ b/pkg/action/action_test.go
@@ -7,10 +7,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/action/audit.go
+++ b/pkg/action/audit.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/audit"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/audit_test.go
+++ b/pkg/action/audit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/binary/binary_test.go
+++ b/pkg/action/binary/binary_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/mockstore"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/binary/cat.go
+++ b/pkg/action/binary/cat.go
@@ -12,6 +12,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/binary/copy.go
+++ b/pkg/action/binary/copy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/fsutil"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
+
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/binary/sum.go
+++ b/pkg/action/binary/sum.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/action"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/clone.go
+++ b/pkg/action/clone.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"path/filepath"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc"
 	gitcli "github.com/justwatchcom/gopass/pkg/backend/rcs/git/cli"
@@ -14,6 +13,8 @@ import (
 	"github.com/justwatchcom/gopass/pkg/fsutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/clone_test.go
+++ b/pkg/action/clone_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/completion.go
+++ b/pkg/action/completion.go
@@ -8,6 +8,7 @@ import (
 
 	fishcomp "github.com/justwatchcom/gopass/pkg/completion/fish"
 	zshcomp "github.com/justwatchcom/gopass/pkg/completion/zsh"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/completion_test.go
+++ b/pkg/action/completion_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/config.go
+++ b/pkg/action/config.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/config_test.go
+++ b/pkg/action/config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/copy.go
+++ b/pkg/action/copy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/justwatchcom/gopass/pkg/termio"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/copy_test.go
+++ b/pkg/action/copy_test.go
@@ -7,10 +7,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/delete.go
+++ b/pkg/action/delete.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/store/sub"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/delete_test.go
+++ b/pkg/action/delete_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/edit.go
+++ b/pkg/action/edit.go
@@ -12,6 +12,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
 	"github.com/justwatchcom/gopass/pkg/tpl"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/edit_test.go
+++ b/pkg/action/edit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/errors.go
+++ b/pkg/action/errors.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/errors_test.go
+++ b/pkg/action/errors_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/action/find.go
+++ b/pkg/action/find.go
@@ -9,6 +9,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/cui"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/schollz/closestmatch"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/find_test.go
+++ b/pkg/action/find_test.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/fsck.go
+++ b/pkg/action/fsck.go
@@ -8,6 +8,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/fsutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/fsck_test.go
+++ b/pkg/action/fsck_test.go
@@ -8,10 +8,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/generate.go
+++ b/pkg/action/generate.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/clipboard"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
@@ -15,6 +14,8 @@ import (
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/generate_test.go
+++ b/pkg/action/generate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/git.go
+++ b/pkg/action/git.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"os"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/cui"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/git_test.go
+++ b/pkg/action/git_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/grep.go
+++ b/pkg/action/grep.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/out"
+
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/grep_test.go
+++ b/pkg/action/grep_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/hibp.go
+++ b/pkg/action/hibp.go
@@ -6,13 +6,14 @@ import (
 	"io/ioutil"
 	"sort"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/hashsum"
 	hibpapi "github.com/justwatchcom/gopass/pkg/hibp/api"
 	hibpdump "github.com/justwatchcom/gopass/pkg/hibp/dump"
 	"github.com/justwatchcom/gopass/pkg/notify"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
+	"github.com/fatih/color"
 	"github.com/muesli/goprogressbar"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/hibp_test.go
+++ b/pkg/action/hibp_test.go
@@ -14,11 +14,11 @@ import (
 	"strings"
 	"testing"
 
-	hibpapi "github.com/justwatchcom/gopass/pkg/hibp/api"
-
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+	hibpapi "github.com/justwatchcom/gopass/pkg/hibp/api"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/history.go
+++ b/pkg/action/history.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/history_test.go
+++ b/pkg/action/history_test.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"testing"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/init.go
+++ b/pkg/action/init.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/agent/client"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/config"
@@ -15,6 +14,8 @@ import (
 	"github.com/justwatchcom/gopass/pkg/pwgen/xkcdgen"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/init_test.go
+++ b/pkg/action/init_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/insert.go
+++ b/pkg/action/insert.go
@@ -15,6 +15,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/insert_test.go
+++ b/pkg/action/insert_test.go
@@ -7,10 +7,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/jsonapi.go
+++ b/pkg/action/jsonapi.go
@@ -6,11 +6,12 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/jsonapi"
 	"github.com/justwatchcom/gopass/pkg/jsonapi/manifest"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/jsonapi_test.go
+++ b/pkg/action/jsonapi_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/list.go
+++ b/pkg/action/list.go
@@ -9,11 +9,12 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/termutil"
 	"github.com/justwatchcom/gopass/pkg/tree"
+
+	"github.com/fatih/color"
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"

--- a/pkg/action/list_test.go
+++ b/pkg/action/list_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/pkg/tree"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/mount.go
+++ b/pkg/action/mount.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/tree/simple"
+
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/mount_test.go
+++ b/pkg/action/mount_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/move.go
+++ b/pkg/action/move.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/justwatchcom/gopass/pkg/termio"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/move_test.go
+++ b/pkg/action/move_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/otp.go
+++ b/pkg/action/otp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/clipboard"
 	"github.com/justwatchcom/gopass/pkg/otp"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/otp_test.go
+++ b/pkg/action/otp_test.go
@@ -8,11 +8,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gokyle/twofactor"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/gokyle/twofactor"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/recipients.go
+++ b/pkg/action/recipients.go
@@ -9,6 +9,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/cui"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/recipients_test.go
+++ b/pkg/action/recipients_test.go
@@ -7,10 +7,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/fatih/color"
 	"github.com/muesli/goprogressbar"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"

--- a/pkg/action/show.go
+++ b/pkg/action/show.go
@@ -11,6 +11,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/qrcon"
 	"github.com/justwatchcom/gopass/pkg/store"
+
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/show_test.go
+++ b/pkg/action/show_test.go
@@ -8,11 +8,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/sync.go
+++ b/pkg/action/sync.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/notify"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
+
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/sync_test.go
+++ b/pkg/action/sync_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/templates.go
+++ b/pkg/action/templates.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/justwatchcom/gopass/pkg/editor"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/templates_test.go
+++ b/pkg/action/templates_test.go
@@ -7,10 +7,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/unclip.go
+++ b/pkg/action/unclip.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/justwatchcom/gopass/pkg/clipboard"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/update.go
+++ b/pkg/action/update.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/updater"
+
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/update_test.go
+++ b/pkg/action/update_test.go
@@ -13,11 +13,12 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/dominikschulz/github-releases/ghrel"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/updater"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/dominikschulz/github-releases/ghrel"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/action/version.go
+++ b/pkg/action/version.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/protect"
 	"github.com/justwatchcom/gopass/pkg/updater"
+
+	"github.com/fatih/color"
 	"github.com/urfave/cli"
 )
 

--- a/pkg/action/version_test.go
+++ b/pkg/action/version_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -13,6 +13,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/agent/client"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/pinentry"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/agent/client/client_others.go
+++ b/pkg/agent/client/client_others.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -8,10 +8,11 @@ import (
 	"io/ioutil"
 	"runtime"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/notify"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
+
+	"github.com/fatih/color"
 	"github.com/muesli/crunchy"
 	"github.com/muesli/goprogressbar"
 )

--- a/pkg/backend/crypto/gpg/cli/export.go
+++ b/pkg/backend/crypto/gpg/cli/export.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/backend/crypto/gpg/cli/generate.go
+++ b/pkg/backend/crypto/gpg/cli/generate.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/backend/crypto/gpg/cli/gpg_windows.go
+++ b/pkg/backend/crypto/gpg/cli/gpg_windows.go
@@ -6,9 +6,9 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/justwatchcom/gopass/pkg/fsutil"
-
 	"golang.org/x/sys/windows/registry"
+
+	"github.com/justwatchcom/gopass/pkg/fsutil"
 )
 
 func detectBinaryCandidates(bin string) ([]string, error) {

--- a/pkg/backend/crypto/gpg/cli/import.go
+++ b/pkg/backend/crypto/gpg/cli/import.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/backend/crypto/gpg/cli/key.go
+++ b/pkg/backend/crypto/gpg/cli/key.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/pkg/errors"
-
 	"golang.org/x/crypto/openpgp"
+
+	"github.com/pkg/errors"
 )
 
 // ReadNamesFromKey unmarshals and returns the names associated with the given public key

--- a/pkg/backend/crypto/gpg/cli/key_test.go
+++ b/pkg/backend/crypto/gpg/cli/key_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/backend/crypto/gpg/openpgp/keyring.go
+++ b/pkg/backend/crypto/gpg/openpgp/keyring.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"golang.org/x/crypto/openpgp"
+
+	"github.com/pkg/errors"
 )
 
 // ListPublicKeyIDs does nothing

--- a/pkg/backend/crypto/gpg/openpgp/utils.go
+++ b/pkg/backend/crypto/gpg/openpgp/utils.go
@@ -8,9 +8,10 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/crypto/openpgp"
+
 	"github.com/justwatchcom/gopass/pkg/out"
 	homedir "github.com/mitchellh/go-homedir"
-	"golang.org/x/crypto/openpgp"
 )
 
 type agentClient interface {

--- a/pkg/backend/crypto/plain/backend.go
+++ b/pkg/backend/crypto/plain/backend.go
@@ -8,8 +8,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/gpg"
+
+	"github.com/blang/semver"
 )
 
 var staticPrivateKeyList = gpg.KeyList{

--- a/pkg/backend/crypto/plain/backend_test.go
+++ b/pkg/backend/crypto/plain/backend_test.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/backend/crypto/xc/compress_test.go
+++ b/pkg/backend/crypto/xc/compress_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/pwgen"
 	"github.com/justwatchcom/gopass/pkg/pwgen/xkcdgen"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/backend/crypto/xc/decrypt.go
+++ b/pkg/backend/crypto/xc/decrypt.go
@@ -7,12 +7,14 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
-	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
-	"github.com/pkg/errors"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/secretbox"
+
+	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
+	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/backend/crypto/xc/encrypt.go
+++ b/pkg/backend/crypto/xc/encrypt.go
@@ -2,20 +2,20 @@ package xc
 
 import (
 	"context"
+	crypto_rand "crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"sort"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
-	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
-	"github.com/pkg/errors"
-
-	crypto_rand "crypto/rand"
-
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/secretbox"
+
+	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
+	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/backend/crypto/xc/encrypt_test.go
+++ b/pkg/backend/crypto/xc/encrypt_test.go
@@ -9,9 +9,10 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
+
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/backend/crypto/xc/export_test.go
+++ b/pkg/backend/crypto/xc/export_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/backend/crypto/xc/import_test.go
+++ b/pkg/backend/crypto/xc/import_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/backend/crypto/xc/keyring/private_key.go
+++ b/pkg/backend/crypto/xc/keyring/private_key.go
@@ -1,17 +1,16 @@
 package keyring
 
 import (
+	crypto_rand "crypto/rand"
 	"fmt"
 	"io"
 	"time"
 
-	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
-
-	crypto_rand "crypto/rand"
-
 	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/secretbox"
+
+	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
 )
 
 // saltLength is chosen based on the recommendation in

--- a/pkg/backend/crypto/xc/keyring/public_key.go
+++ b/pkg/backend/crypto/xc/keyring/public_key.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
-
 	"golang.org/x/crypto/sha3"
+
+	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
 )
 
 // PublicKeyAlgorithm is a type of public key algorithm

--- a/pkg/backend/crypto/xc/keyring/pubring.go
+++ b/pkg/backend/crypto/xc/keyring/pubring.go
@@ -8,8 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
+
+	"github.com/golang/protobuf/proto"
 )
 
 // Pubring is a public key ring

--- a/pkg/backend/crypto/xc/keyring/secring.go
+++ b/pkg/backend/crypto/xc/keyring/secring.go
@@ -8,8 +8,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
+
+	"github.com/golang/protobuf/proto"
 )
 
 // Secring is private key ring

--- a/pkg/backend/crypto/xc/utils.go
+++ b/pkg/backend/crypto/xc/utils.go
@@ -6,9 +6,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/xcpb"
+
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/backend/crypto/xc/utils_test.go
+++ b/pkg/backend/crypto/xc/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/backend/crypto/xc/xc.go
+++ b/pkg/backend/crypto/xc/xc.go
@@ -5,8 +5,9 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/xc/keyring"
+
+	"github.com/blang/semver"
 )
 
 const (

--- a/pkg/backend/rcs/git/cli/config.go
+++ b/pkg/backend/rcs/git/cli/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/backend/rcs/git/cli/config_test.go
+++ b/pkg/backend/rcs/git/cli/config_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/backend/rcs/git/cli/git.go
+++ b/pkg/backend/rcs/git/cli/git.go
@@ -12,12 +12,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/fsutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
+
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/backend/rcs/git/cli/git_test.go
+++ b/pkg/backend/rcs/git/cli/git_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/backend/rcs/git/gogit/git.go
+++ b/pkg/backend/rcs/git/gogit/git.go
@@ -9,12 +9,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
-	"github.com/pkg/errors"
 
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"

--- a/pkg/backend/rcs/git/gogit/git_test.go
+++ b/pkg/backend/rcs/git/gogit/git_test.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"gopkg.in/src-d/go-git.v4/config"
-
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/store"
+
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/src-d/go-git.v4/config"
 )
 
 func TestCloneLocal(t *testing.T) {

--- a/pkg/backend/rcs/noop/backend.go
+++ b/pkg/backend/rcs/noop/backend.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/backend"
+
+	"github.com/blang/semver"
 )
 
 // Noop is a no-op git backend

--- a/pkg/backend/storage/fs/store.go
+++ b/pkg/backend/storage/fs/store.go
@@ -8,9 +8,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/fsutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
+	"github.com/blang/semver"
 )
 
 // Store is a fs based store

--- a/pkg/backend/storage/kv/consul/store.go
+++ b/pkg/backend/storage/kv/consul/store.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"strings"
 
+	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/blang/semver"
 	api "github.com/hashicorp/consul/api"
-	"github.com/justwatchcom/gopass/pkg/out"
 )
 
 // Store is a consul-backed store

--- a/pkg/backend/url_test.go
+++ b/pkg/backend/url_test.go
@@ -3,9 +3,8 @@ package backend
 import (
 	"testing"
 
-	yaml "gopkg.in/yaml.v2"
-
 	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
 )
 
 /*

--- a/pkg/clipboard/clipboard.go
+++ b/pkg/clipboard/clipboard.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/atotto/clipboard"
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
+	"github.com/atotto/clipboard"
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/clipboard/clipboard_test.go
+++ b/pkg/clipboard/clipboard_test.go
@@ -6,8 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/atotto/clipboard"
 	"github.com/justwatchcom/gopass/pkg/out"
+
+	"github.com/atotto/clipboard"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/clipboard/unclip.go
+++ b/pkg/clipboard/unclip.go
@@ -5,8 +5,9 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/atotto/clipboard"
 	"github.com/justwatchcom/gopass/pkg/notify"
+
+	"github.com/atotto/clipboard"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/clipboard/unclip_test.go
+++ b/pkg/clipboard/unclip_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/backend"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/config/context_test.go
+++ b/pkg/config/context_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/config/io.go
+++ b/pkg/config/io.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/fsutil"
+
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )

--- a/pkg/config/io_test.go
+++ b/pkg/config/io_test.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/backend"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/config/location.go
+++ b/pkg/config/location.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/justwatchcom/gopass/pkg/fsutil"
+
 	homedir "github.com/mitchellh/go-homedir"
 )
 

--- a/pkg/config/secrets/config.go
+++ b/pkg/config/secrets/config.go
@@ -8,11 +8,12 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
-	"github.com/justwatchcom/gopass/pkg/fsutil"
-	"github.com/pkg/errors"
-
 	"golang.org/x/crypto/argon2"
 	"golang.org/x/crypto/nacl/secretbox"
+
+	"github.com/justwatchcom/gopass/pkg/fsutil"
+
+	"github.com/pkg/errors"
 )
 
 const (

--- a/pkg/config/store_config.go
+++ b/pkg/config/store_config.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/justwatchcom/gopass/pkg/backend"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/cui/cui.go
+++ b/pkg/cui/cui.go
@@ -7,10 +7,11 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/fatih/color"
-	"github.com/jroimartin/gocui"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/termwiz"
+
+	"github.com/fatih/color"
+	"github.com/jroimartin/gocui"
 )
 
 type selection struct {

--- a/pkg/cui/cui_test.go
+++ b/pkg/cui/cui_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/cui/recipients.go
+++ b/pkg/cui/recipients.go
@@ -16,6 +16,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/editor"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/cui/recipients_test.go
+++ b/pkg/cui/recipients_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/backend/crypto/plain"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/editor/edit_test.go
+++ b/pkg/editor/edit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 )

--- a/pkg/editor/editor.go
+++ b/pkg/editor/editor.go
@@ -8,10 +8,11 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/tempfile"
+
+	"github.com/fatih/color"
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"
 )

--- a/pkg/hibp/api/client.go
+++ b/pkg/hibp/api/client.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
 	"github.com/justwatchcom/gopass/pkg/out"
+
+	"github.com/cenkalti/backoff"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/jsonapi/api_test.go
+++ b/pkg/jsonapi/api_test.go
@@ -2,9 +2,8 @@ package jsonapi
 
 import (
 	"bytes"
-	"encoding/binary"
-
 	"context"
+	"encoding/binary"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -17,6 +16,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/store/root"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/jsonapi/manifest/setup.go
+++ b/pkg/jsonapi/manifest/setup.go
@@ -3,11 +3,9 @@ package manifest
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
-
-	"io/ioutil"
-
 	"path/filepath"
 
 	homedir "github.com/mitchellh/go-homedir"

--- a/pkg/jsonapi/messages_test.go
+++ b/pkg/jsonapi/messages_test.go
@@ -1,10 +1,9 @@
 package jsonapi
 
 import (
-	"testing"
-
 	"bytes"
 	"encoding/json"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/jsonapi/responses.go
+++ b/pkg/jsonapi/responses.go
@@ -2,17 +2,16 @@ package jsonapi
 
 import (
 	"context"
-
 	"encoding/json"
 	"fmt"
+	"path"
 	"regexp"
 	"strings"
-
-	"path"
 
 	"github.com/justwatchcom/gopass/pkg/pwgen"
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/notify/notify_linux.go
+++ b/pkg/notify/notify_linux.go
@@ -6,8 +6,9 @@ import (
 	"context"
 	"os"
 
-	"github.com/godbus/dbus"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
+	"github.com/godbus/dbus"
 )
 
 // Notify displays a desktop notification with dbus

--- a/pkg/otp/otp.go
+++ b/pkg/otp/otp.go
@@ -5,8 +5,9 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/gokyle/twofactor"
 	"github.com/justwatchcom/gopass/pkg/store"
+
+	"github.com/gokyle/twofactor"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/out/print.go
+++ b/pkg/out/print.go
@@ -6,8 +6,9 @@ import (
 	"io"
 	"os"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
+	"github.com/fatih/color"
 )
 
 // Stdout is exported for tests

--- a/pkg/out/print_test.go
+++ b/pkg/out/print_test.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/fsck_test.go
+++ b/pkg/store/root/fsck_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/git.go
+++ b/pkg/store/root/git.go
@@ -3,9 +3,10 @@ package root
 import (
 	"context"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/store"
+
+	"github.com/blang/semver"
 )
 
 // RCS returns the sync backend

--- a/pkg/store/root/init.go
+++ b/pkg/store/root/init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/root/init_test.go
+++ b/pkg/store/root/init_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/list.go
+++ b/pkg/store/root/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/tree"
 	"github.com/justwatchcom/gopass/pkg/tree/simple"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/root/list_test.go
+++ b/pkg/store/root/list_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/mount.go
+++ b/pkg/store/root/mount.go
@@ -5,13 +5,14 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
 	"github.com/justwatchcom/gopass/pkg/store/vault"
+
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/root/mount_test.go
+++ b/pkg/store/root/mount_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/move.go
+++ b/pkg/store/root/move.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/justwatchcom/gopass/pkg/store/sub"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/root/move_test.go
+++ b/pkg/store/root/move_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/read_test.go
+++ b/pkg/store/root/read_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/recipients.go
+++ b/pkg/store/root/recipients.go
@@ -5,11 +5,12 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/tree"
 	"github.com/justwatchcom/gopass/pkg/tree/simple"
+
+	"github.com/fatih/color"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/root/recipients_test.go
+++ b/pkg/store/root/recipients_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/store.go
+++ b/pkg/store/root/store.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/store/sub"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/root/store_test.go
+++ b/pkg/store/root/store_test.go
@@ -2,14 +2,14 @@ package root
 
 import (
 	"context"
+	"path"
 	"sort"
 	"testing"
-
-	"path"
 
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/config"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/templates.go
+++ b/pkg/store/root/templates.go
@@ -8,6 +8,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/tree"
 	"github.com/justwatchcom/gopass/pkg/tree/simple"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/root/templates_test.go
+++ b/pkg/store/root/templates_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/root/write_test.go
+++ b/pkg/store/root/write_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
 	"github.com/justwatchcom/gopass/tests/gptest"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/secret/secret_test.go
+++ b/pkg/store/secret/secret_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/store"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/secret/yaml.go
+++ b/pkg/store/secret/yaml.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/justwatchcom/gopass/pkg/store"
+
 	yaml "gopkg.in/yaml.v2"
 )
 

--- a/pkg/store/sub/fsck.go
+++ b/pkg/store/sub/fsck.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/sub/fsck_test.go
+++ b/pkg/store/sub/fsck_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/backend/storage/fs"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/sub/git.go
+++ b/pkg/store/sub/git.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/sub/git_test.go
+++ b/pkg/store/sub/git_test.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/blang/semver"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/sub/gpg.go
+++ b/pkg/store/sub/gpg.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/sub/gpg_test.go
+++ b/pkg/store/sub/gpg_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/muesli/goprogressbar"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/store/sub/init.go
+++ b/pkg/store/sub/init.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/sub/list_test.go
+++ b/pkg/store/sub/list_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/backend/storage/fs"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/sub/move.go
+++ b/pkg/store/sub/move.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/sub/move_test.go
+++ b/pkg/store/sub/move_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/backend/storage/fs"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/sub/recipients.go
+++ b/pkg/store/sub/recipients.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/sub/recipients_test.go
+++ b/pkg/store/sub/recipients_test.go
@@ -16,6 +16,7 @@ import (
 	noop "github.com/justwatchcom/gopass/pkg/backend/rcs/noop"
 	"github.com/justwatchcom/gopass/pkg/backend/storage/fs"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/sub/storage.go
+++ b/pkg/store/sub/storage.go
@@ -10,6 +10,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/backend/storage/kv/inmem"
 	"github.com/justwatchcom/gopass/pkg/config/secrets"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/sub/store.go
+++ b/pkg/store/sub/store.go
@@ -12,6 +12,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
+
 	"github.com/muesli/goprogressbar"
 	"github.com/pkg/errors"
 )

--- a/pkg/store/sub/store_test.go
+++ b/pkg/store/sub/store_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/store/secret"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/sub/templates.go
+++ b/pkg/store/sub/templates.go
@@ -11,6 +11,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/store"
 	"github.com/justwatchcom/gopass/pkg/tree"
 	"github.com/justwatchcom/gopass/pkg/tree/simple"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/sub/templates_test.go
+++ b/pkg/store/sub/templates_test.go
@@ -6,8 +6,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/justwatchcom/gopass/pkg/backend"
+
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/sub/write.go
+++ b/pkg/store/sub/write.go
@@ -8,6 +8,7 @@ import (
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/store/sub/write_test.go
+++ b/pkg/store/sub/write_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/store/secret"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/store/vault/store.go
+++ b/pkg/store/vault/store.go
@@ -8,11 +8,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/hashicorp/vault/api"
 	"github.com/justwatchcom/gopass/pkg/agent/client"
 	"github.com/justwatchcom/gopass/pkg/backend"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/store"
+
+	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/tempfile/file.go
+++ b/pkg/tempfile/file.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/tempfile/mount_darwin.go
+++ b/pkg/tempfile/mount_darwin.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
+	"github.com/cenkalti/backoff"
 	"github.com/pkg/errors"
 )
 

--- a/pkg/termio/ask.go
+++ b/pkg/termio/ask.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/termio/ask_test.go
+++ b/pkg/termio/ask_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/termio/promptpass_others.go
+++ b/pkg/termio/promptpass_others.go
@@ -8,10 +8,12 @@ import (
 	"os"
 	"os/signal"
 
+	"golang.org/x/crypto/ssh/terminal"
+
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // promptPass will prompt user's for a password by terminal.

--- a/pkg/termio/promptpass_test.go
+++ b/pkg/termio/promptpass_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/termwiz/selection.go
+++ b/pkg/termwiz/selection.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gdamore/tcell/termbox"
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
+	"github.com/gdamore/tcell/termbox"
 	runewidth "github.com/mattn/go-runewidth"
 )
 

--- a/pkg/termwiz/selection_test.go
+++ b/pkg/termwiz/selection_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/ctxutil"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/tree/simple/folder.go
+++ b/pkg/tree/simple/folder.go
@@ -2,11 +2,11 @@ package simple
 
 import (
 	"bytes"
+	"path"
 	"strings"
 
-	"path"
-
 	"github.com/justwatchcom/gopass/pkg/tree"
+
 	"github.com/pkg/errors"
 )
 

--- a/pkg/tree/simple/tree_test.go
+++ b/pkg/tree/simple/tree_test.go
@@ -1,11 +1,10 @@
 package simple
 
 import (
+	"path/filepath"
 	"sort"
 	"strings"
 	"testing"
-
-	"path/filepath"
 
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"

--- a/pkg/updater/update.go
+++ b/pkg/updater/update.go
@@ -17,12 +17,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/blang/semver"
-	"github.com/cenkalti/backoff"
-
-	"github.com/dominikschulz/github-releases/ghrel"
 	"github.com/justwatchcom/gopass/pkg/out"
 	"github.com/justwatchcom/gopass/pkg/termio"
+
+	"github.com/blang/semver"
+	"github.com/cenkalti/backoff"
+	"github.com/dominikschulz/github-releases/ghrel"
 	"github.com/muesli/goprogressbar"
 	"github.com/pkg/errors"
 )

--- a/pkg/updater/update_others.go
+++ b/pkg/updater/update_others.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/justwatchcom/gopass/pkg/out"
+
 	"github.com/pkg/errors"
 )
 

--- a/tests/gptest/unit.go
+++ b/tests/gptest/unit.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/justwatchcom/gopass/pkg/backend"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/tests/jsonapi_test.go
+++ b/tests/jsonapi_test.go
@@ -2,10 +2,9 @@ package tests
 
 import (
 	"bytes"
+	"encoding/binary"
 	"io"
 	"testing"
-
-	"encoding/binary"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/tests/tester.go
+++ b/tests/tester.go
@@ -3,16 +3,14 @@ package tests
 import (
 	"bytes"
 	"context"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
-
-	"io"
-
-	"runtime"
 
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"


### PR DESCRIPTION
Grouped in the following order:
1. Packages from the std library
2. golang.org imports
3. github.com/justwatchcom/gopass packages
4. External dependencies

Sorted by gofmt.

My fingers are bleeding.