### PR TITLE
reencrypt removes the repository name to avoid key path errors.

### DIFF
--- a/pkg/store/sub/store.go
+++ b/pkg/store/sub/store.go
@@ -175,6 +175,7 @@ func (s *Store) reencrypt(ctx context.Context) error {
 				bar.LazyPrint()
 			}
 
+			e = strings.TrimLeft(e, s.alias)
 			content, err := s.Get(ctx, e)
 			if err != nil {
 				out.Red(ctx, "Failed to get current value for %s: %s", e, err)


### PR DESCRIPTION
I found that a new public key or a public key to be added when I reencrypted the repository password would have an error that could not be obtained. I tried to modify it so I didn't know if it was reasonable.

This error is mainly because key, when getting the repository password list, contains the name of the repository, and the direct use of this key name will not find the file, and I try to delete the name of the key repository.

The mistakes I encountered when I added a contact were as follows:

```text
Reencrypting existing secrets. This may take some time ...
(*sub.Store)(0xc4202b1500)(Store(Alias: deploy_macro, Path: gpgcli-gitcli-fs+file:///Users/deploy_macro))
1 of 32 secrets reencrypted    [#>-------------------------------------------------------------------------]   3.12%
Failed to get current value for deploy_macro/deploy/key: Entry is not in the password store
Failed to get current value for deploy_macro/deploy/key1: Entry is not in the password store
Failed to get current value for deploy_macro/deploy/key2: Entry is not in the password store
Failed to get current value for deploy_macro/deploy/key3: Entry is not in the password store
Failed to get current value for deploy_macro/deploy/key4: Entry is not in the password store
......
```