### PR TITLE
Do not overwrite local manifest in tests by calling jsonapi configure

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -109,6 +109,10 @@ func testCommands(t *testing.T, c *cli.Context, commands []cli.Command, prefix s
 			// the agent command is blocking
 			continue
 		}
+		if cmd.Name == "configure" && prefix == ".jsonapi" {
+			// running jsonapi configure will overwrite the chrome manifest
+			continue
+		}
 		if len(cmd.Subcommands) > 0 {
 			testCommands(t, c, cmd.Subcommands, prefix+"."+cmd.Name)
 		}


### PR DESCRIPTION
Fixes #778